### PR TITLE
Adding jsreport

### DIFF
--- a/public/v1/apps/jsreport.json
+++ b/public/v1/apps/jsreport.json
@@ -27,7 +27,7 @@
     "variables": [{
             "id": "$$cap_jsreport_version",
             "label": "version",
-            "defaultValue": "latest-full",
+            "defaultValue": "2.4.0-full",
             "description": "Checkout their docker page for the valid tags https://hub.docker.com/r/jsreport/jsreport/tags",
             "validRegex": "/^([^\\s^\\/])+$/"
         },

--- a/public/v1/apps/jsreport.json
+++ b/public/v1/apps/jsreport.json
@@ -40,7 +40,7 @@
         },
         {
             "id": "$$cap_jsreport_password",
-            "label": "Admin password password",
+            "label": "Admin password",
             "validRegex": "/^\\s*\\S.*$/"
         },
 		 {

--- a/public/v1/apps/jsreport.json
+++ b/public/v1/apps/jsreport.json
@@ -11,7 +11,7 @@
                     "$$cap_appname-db-config:/data/configdb"
                 ],
                 "restart": "always",
-				"containerHttpPort": "8080",
+				"containerHttpPort": "5488",
                 "environment": {
                     "extensions_authentication_admin_username": "$$cap_jsreport_adminusername",
                     "extensions_authentication_admin_password": "$$cap_jsreport_password",
@@ -22,7 +22,7 @@
     },
     "instructions": {
         "start": "Reporting tools for creating PDF, HTMLS, Excel by converting your HTML + CSS + Javascript knowledge.",
-        "end": "You need to set the port 5488 on container http port so you can use it outside."
+        "end": "Congratulations! You have the new jsReport instance running. Happy reporting!"
     },
     "variables": [{
             "id": "$$cap_jsreport_version",

--- a/public/v1/apps/jsreport.json
+++ b/public/v1/apps/jsreport.json
@@ -1,0 +1,54 @@
+{
+    "captainVersion": "1",
+    "documentation": "Taken from https://hub.docker.com/r/jsreport/jsreport/",
+    "dockerCompose": {
+        "version": "3.3",
+        "services": {
+            "$$cap_appname": {
+                "image": "jsreport/jsreport:$$cap_jsreport_version",                
+                "volumes": [
+                    "$$cap_appname-db-data:/data/db",
+                    "$$cap_appname-db-config:/data/configdb"
+                ],
+                "restart": "always",
+				"containerHttpPort": "8080",
+                "environment": {
+                    "extensions_authentication_admin_username": "$$cap_jsreport_adminusername",
+                    "extensions_authentication_admin_password": "$$cap_jsreport_password",
+					          "extensions_authentication_cookieSession_secret": "$$cap_jsreport_secret"
+                }
+            }
+        }
+    },
+    "instructions": {
+        "start": "Reporting tools for creating PDF, HTMLS, Excel by converting your HTML + CSS + Javascript knowledge.",
+        "end": "You need to set the port 5488 on container http port so you can use it outside."
+    },
+    "variables": [{
+            "id": "$$cap_jsreport_version",
+            "label": "version",
+            "defaultValue": "latest-full",
+            "description": "Checkout their docker page for the valid tags https://hub.docker.com/r/jsreport/jsreport/tags",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        },
+        {
+            "id": "$$cap_jsreport_adminusername",
+            "label": "Admin user name",
+            "defaultValue": "admin",
+            "description": "Only use alphanumeric chars.",
+            "validRegex": "/^([a-zA-Z0-9])+$/"
+        },
+        {
+            "id": "$$cap_jsreport_password",
+            "label": "Admin password password",
+            "validRegex": "/^\\s*\\S.*$/"
+        },
+		 {
+            "id": "$$cap_jsreport_secret",
+            "label": "Session secret",
+			"defaultValue": "long-secret",
+            "validRegex": "/^\\s*\\S.*$/"
+        }
+    ]
+
+}


### PR DESCRIPTION
**jsreport** is good alternative for reporting that runs on javascript platform.
according to them it Javascript reporting server with innovative and unlimited reporting based on javascript templating engines

https://jsreport.net/ -- official site
https://hub.docker.com/r/jsreport/jsreport/ -- official docker repo


I was able to test and use this template on my caprover instance and it works as expectd, using the latest tag