### PR TITLE
Upgrade Thumbor

### DIFF
--- a/public/v1/apps/thumbor.json
+++ b/public/v1/apps/thumbor.json
@@ -1,11 +1,11 @@
 {
     "captainVersion": "1",
-    "documentation": "Taken from https://hub.docker.com/r/apsl/thumbor/tags/",
+    "documentation": "Taken from https://hub.docker.com/r/minimalcompact/thumbor/tags/",
     "dockerCompose": {
         "version": "3.3",
         "services": {
             "$$cap_appname-db": {
-                "image": "apsl/thumbor:$$cap_thumbor_version",
+                "image": "minimalcompact/thumbor:$$cap_thumbor_version",
                 "volumes": [
                     "$$cap_appname-thumbor:/data"
                 ],
@@ -23,8 +23,8 @@
     "variables": [{
         "id": "$$cap_thumbor_version",
         "label": "Thumbor Version",
-        "defaultValue": "6.4.2",
-        "description": "Checkout their docker page for the valid tags https://hub.docker.com/r/apsl/thumbor/tags/",
+        "defaultValue": "6.7.0",
+        "description": "Checkout their docker page for the valid tags https://hub.docker.com/r/minimalcompact/thumbor/tags/",
         "validRegex": "/^([^\\s^\\/])+$/"
     }]
 


### PR DESCRIPTION
* APSL/thumbor is not actively maintained and doesn't have the latest versions
* [MinimaCompact](https://github.com/MinimalCompact/thumbor) is actively maintained and works closely with the thumbor core team
* This change switches to use minimalcompact and also upgrades the default version to the latest
* Note: not sure if it's worth hard-coding an explicit version `6.7.0` or use the `latest` tag?