### PR TITLE
Fix problem with port number on Ghost

### DIFF
--- a/public/v1/apps/ghost.json
+++ b/public/v1/apps/ghost.json
@@ -1,0 +1,150 @@
+{
+   "captainVersion":"1",
+   "documentation":"Taken from https://docs.ghost.org/",
+   "dockerCompose":{
+      "services":{
+         "$$cap_appname":{
+            "containerHttpPort":"2368",
+            "environment":{
+               "GHOST_DATABASE_NAME":"ghost",
+               "GHOST_DATABASE_PASSWORD":"$$cap_db_ghost_password",
+               "GHOST_DATABASE_USER":"ghost",
+               "GHOST_EMAIL":"$$cap_ghost_email",
+               "GHOST_HOST":"$$cap_ghost_host",
+               "GHOST_PASSWORD":"$$cap_ghost_password",
+               "GHOST_PROTOCOL":"$$cap_ghost_protocol",
+               "MARIADB_HOST":"srv-captain--$$cap_appname-db",
+               "MARIADB_PORT_NUMBER":"3306",
+               "SMTP_FROM_ADDRESS":"$$cap_ghost_smtp_from",
+               "SMTP_HOST":"$$cap_ghost_smtp_host",
+               "SMTP_PASSWORD":"$$cap_ghost_smtp_password",
+               "SMTP_PORT":"$$cap_ghost_smtp_port",
+               "SMTP_SERVICE":"$$cap_ghost_smtp_service",
+               "SMTP_USER":"$$cap_ghost_smtp_user"
+            },
+            "image":"bitnami/ghost:$$cap_ghost_version",
+            "restart":"always",
+            "volumes":[
+               "$$cap_appname-data:/bitnami"
+            ]
+         },
+         "$$cap_appname-db":{
+            "environment":{
+               "MARIADB_DATABASE":"ghost",
+               "MARIADB_PASSWORD":"$$cap_db_ghost_password",
+               "MARIADB_ROOT_PASSWORD":"$$cap_db_password",
+               "MARIADB_ROOT_USER":"$$cap_db_user",
+               "MARIADB_USER":"ghost"
+            },
+            "image":"bitnami/mariadb:latest",
+            "restart":"always",
+            "volumes":[
+               "$$cap_appname-mariadb-data:/bitnami"
+            ]
+         }
+      },
+      "version":"2",
+      "volumes":{
+         "$$cap_appname-data":{
+
+         },
+         "$$cap_appname-mariadb-data":{
+
+         }
+      }
+   },
+   "instructions":{
+      "end":"Ghost is deployed and available as $$cap_appname. \n\n IMPORTANT: It will take up to 2 minutes for Ghost to be ready. Before that, you might see 502 error page.\n",
+      "start":"Ghost is a fully open source, adaptable platform for building and running a modern online publication. We power blogs, magazines and journalists from Zappos to Sky News."
+   },
+   "variables":[
+      {
+         "defaultValue":"latest",
+         "description":"Checkout their docker page for the valid tags https://hub.docker.com/r/bitnami/ghost/tags",
+         "id":"$$cap_ghost_version",
+         "label":"Ghost Version",
+         "validRegex":"/^([^\\s^\\/])+$/"
+      },
+      {
+         "defaultValue":"admin",
+         "description":"Root user that will be created on MariaDB",
+         "id":"$$cap_db_user",
+         "label":"MariaDB root user",
+         "validRegex":"/^([^\\s^\\/])+$/"
+      },
+      {
+         "description":"Root password that will be created on MariaDB",
+         "id":"$$cap_db_password",
+         "label":"MariaDB root password",
+         "validRegex":"/^(?=.*\\d).{10,}$/"
+      },
+      {
+         "description":"Password for database user named `ghost`",
+         "id":"$$cap_db_ghost_password",
+         "label":"MariaDB Ghost password",
+         "validRegex":"/^(?=.*\\d).{10,}$/"
+      },
+      {
+         "defaultValue":"youremail@example.com",
+         "description":"Ghost application email, you will use it to login",
+         "id":"$$cap_ghost_email",
+         "label":"Ghost email",
+         "validRegex":"/^([^\\s^\\/])+$/"
+      },
+      {
+         "description":"The admin password must be at least 10 characters, and at least one number and letter",
+         "id":"$$cap_ghost_password",
+         "label":"Ghost password",
+         "validRegex":"/^(?=.*\\d).{10,}$/"
+      },
+      {
+         "defaultValue":"example.com/blog",
+         "description":"Enter the URL that is used to access your publication",
+         "id":"$$cap_ghost_host",
+         "label":"Ghost Host",
+         "validRegex":"/^([^\\s^\\/])+$/"
+      },
+      {
+         "defaultValue":"https",
+         "description":"Protocol that you will be using",
+         "id":"$$cap_ghost_protocol",
+         "label":"Ghost Protocol",
+         "validRegex":"/^([^\\s^\\/])+$/"
+      },
+      {
+         "defaultValue":"GMail",
+         "description":"Ghost uses node mailer, check this docs https://docs.ghost.org/concepts/config/#mail",
+         "id":"$$cap_ghost_smtp_service",
+         "label":"STMP service to use"
+      },
+      {
+         "defaultValue":"smtp.gmail.com",
+         "description":"The STMP host you will be using",
+         "id":"$$cap_ghost_smtp_host",
+         "label":"STMP host"
+      },
+      {
+         "defaultValue":"465",
+         "description":"The STMP port you will be using",
+         "id":"$$cap_ghost_smtp_port",
+         "label":"STMP port"
+      },
+      {
+         "defaultValue":"your_email@gmail.com",
+         "description":"Your user on the SMTP service",
+         "id":"$$cap_ghost_smtp_user",
+         "label":"STMP user"
+      },
+      {
+         "description":"Your password on the SMTP service",
+         "id":"$$cap_ghost_smtp_password",
+         "label":"STMP password"
+      },
+      {
+         "defaultValue":"your_email@gmail.com",
+         "description":"STMP from address",
+         "id":"$$cap_ghost_smtp_from",
+         "label":"STMP from address"
+      }
+   ]
+}


### PR DESCRIPTION
For some reason, the port was defaulting to 2368 and it was constructing the application URLs wrong.

Instead of `http://cap-app.myroot.example.com/`,
it was generating the url `http://cap-app.myroot.example.com:2368/`

Also, I have two suggestions, I think this is not the right place to do it, but here we go:

1. I think it's a good ideia to change the select component from the one-click-app UI, to allow searching, because the number of apps is increasing.  https://ant.design/components/select/

2. When building this template I originally used the official ghost image instead of the image from bitnami. But I had a problem using env variables to configure SMTP options. In the original [config](https://docs.ghost.org/concepts/config/#mail) docs it goes like this:

```javascript
"mail": {
    "transport": "SMTP",
    "options": {
        "service": "Mailgun",
        "auth": {
            "user": "postmaster@example.mailgun.org",
            "pass": "1234567890"
        }
    }
}
```

But I didn't know how to configure this using `env` variables. What do you think is the default behavior when the config looks like that?