### PR TITLE
add elasticsearch (single and cluster)

### DIFF
--- a/public/v1/apps/elasticsearch.json
+++ b/public/v1/apps/elasticsearch.json
@@ -67,7 +67,7 @@
             "id": "$$cap_container_port",
             "label": "Container TCP Port",
             "defaultValue": "9200",
-            "description": "Port of of Elasticsearch to be exposed by the container.",
+            "description": "Internal port for Elasticsearch the container listens to.",
             "validRegex": "/^([0-9])+$/"
         }
     ]

--- a/public/v1/apps/elasticsearch.json
+++ b/public/v1/apps/elasticsearch.json
@@ -1,0 +1,83 @@
+{
+    "captainVersion": 1,
+    "documentation": "Elasticsearch (Single and Cluster). Taken from docker.elastic.co/elasticsearch/elasticsearch",
+    "dockerCompose": {
+        "version": "3.3",
+        "services": {
+            "$$cap_appname": {
+                "image" : "docker.elastic.co/elasticsearch/elasticsearch:$$cap_elasticsearch_version",
+                "notExposeAsWebApp": "true",
+                "volumes": [
+                    "$$cap_appname-elasticsearch-data:/usr/share/elasticsearch/data"
+                ],
+                "restart": "always",
+                "environment": {
+                    "ES_JAVA_OPTS": "-Xms512m -Xmx512m",
+                    "cluster.name": "$$cap_elasticsearch_cluster_name",
+                    "http.port": "$$cap_container_port",
+                    "node.master": "$$cap_elasticsearch_node_master",
+                    "node.data": "$$cap_elasticsearch_node_data",
+                    "discovery.zen.minimum_master_nodes": "$$cap_elasticsearch_minimum_master_nodes",
+                    "discovery.zen.ping.unicast.hosts": "$$cap_elasticsearch_unicast_hosts"
+                },
+                "ports": [
+                    "$$cap_host_port:$$cap_container_port"
+                ]
+            }
+        }
+    },
+    "instructions": {
+        "start": "Elasticsearch search engine. Be sure to extend the virtual memory on your host nodes! (increase \"echo 'vm.max_map_count=262144' >> /etc/sysctl.conf\" and restart \"sysctl -p\")",
+        "end": "Elasticsearch is deployed as $$cap_appname. Goto %%cap_host_port/_cat/health to check the health of your cluster."
+    },
+    "variables": [{
+            "id": "$$cap_elasticsearch_version",
+            "label": "Elasticsearch Version Tag ",
+            "description": "Checkout the releases overview: https://www.elastic.co/de/downloads/elasticsearch",
+            "defaultValue": "6.7.1",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        },{
+            "id": "$$cap_elasticsearch_cluster_name",
+            "label": "Cluster Name",
+            "description": "Only nodes within the same cluster name can be combined",
+            "defaultValue": "elasticsearch-cluster",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        },{
+            "id": "$$cap_elasticsearch_unicast_hosts",
+            "label": "Unicasts hosts",
+            "description": "References to other node to attach to. (for example: srv-captain--XXX)",
+            "defaultValue": "false",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        },{
+            "id": "$$cap_elasticsearch_node_data",
+            "label": "Node Data",
+            "description": "Should the node used for storing data? (true / false)",
+            "defaultValue": "true",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        },{
+            "id": "$$cap_elasticsearch_node_master",
+            "label": "Node Master",
+            "description": "Define node as master-eligible (usual first node YES, others NO).",
+            "defaultValue": "true",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        },{
+            "id": "$$cap_elasticsearch_minimum_master_nodes",
+            "label": "Minimum Master Nodes",
+            "description": "Define minimum amount of master (N) ( best practice: ceil(N/2 + 1) ).",
+            "defaultValue": "1",
+            "validRegex": "/^([0-9])+$/"
+        },{
+            "id": "$$cap_host_port",
+            "label": "Host Port",
+            "defaultValue": "9200",
+            "description": "External port of Elasticsearch exposed by the host.",
+            "validRegex": "/^([0-9])+$/"
+        },{
+            "id": "$$cap_container_port",
+            "label": "Container TCP Port",
+            "defaultValue": "9200",
+            "description": "Internal port for Elasticsearch the container listens to.",
+            "validRegex": "/^([0-9])+$/"
+        }
+    ]
+}

--- a/public/v1/apps/elasticsearch.json
+++ b/public/v1/apps/elasticsearch.json
@@ -27,7 +27,7 @@
         }
     },
     "instructions": {
-        "start": "Elasticsearch search engine. Be sure to extend the virtual memory on your host nodes! (increase \"echo 'vm.max_map_count=262144' >> /etc/sysctl.conf\" and restart \"sysctl -p\")",
+        "start": "Elasticsearch search engine. Be sure to extend the virtual memory on all your hosts! (increase \"echo 'vm.max_map_count=262144' >> /etc/sysctl.conf\" and restart \"sysctl -p\")",
         "end": "Elasticsearch is deployed as $$cap_appname. Goto %%cap_host_port/_cat/health to check the health of your cluster."
     },
     "variables": [{

--- a/public/v1/apps/elasticsearch.json
+++ b/public/v1/apps/elasticsearch.json
@@ -1,12 +1,11 @@
 {
     "captainVersion": 1,
-    "documentation": "Elasticsearch (Single and Cluster). Taken from docker.elastic.co/elasticsearch/elasticsearch",
+    "documentation": "Elasticsearch is a distributed, RESTful search and analytics engine. This image can be used for single nodes and cluster setups. Look at https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html for further assistance using Elasticsearch with docker.",
     "dockerCompose": {
         "version": "3.3",
         "services": {
             "$$cap_appname": {
                 "image" : "docker.elastic.co/elasticsearch/elasticsearch:$$cap_elasticsearch_version",
-                "notExposeAsWebApp": "true",
                 "volumes": [
                     "$$cap_appname-elasticsearch-data:/usr/share/elasticsearch/data"
                 ],
@@ -20,15 +19,13 @@
                     "discovery.zen.minimum_master_nodes": "$$cap_elasticsearch_minimum_master_nodes",
                     "discovery.zen.ping.unicast.hosts": "$$cap_elasticsearch_unicast_hosts"
                 },
-                "ports": [
-                    "$$cap_host_port:$$cap_container_port"
-                ]
+                "containerHttpPort": "$$cap_container_port"
             }
         }
     },
     "instructions": {
-        "start": "Elasticsearch search engine. Be sure to extend the virtual memory on all your hosts! (increase \"echo 'vm.max_map_count=262144' >> /etc/sysctl.conf\" and restart \"sysctl -p\")",
-        "end": "Elasticsearch is deployed as $$cap_appname. Goto %%cap_host_port/_cat/health to check the health of your cluster."
+        "start": "Elasticsearch startearch engine. Be sure to extend the virtual memory on all your hosts! (increase \"echo 'vm.max_map_count=262144' >> /etc/sysctl.conf\" and restart \"sysctl -p\")",
+        "end": "Deployment of Elasticsearch is finished. You might see 502 errors for the next 2 minutes. Goto <YOUR-APP-URL>/_cat/health to check the health of your cluster."
     },
     "variables": [{
             "id": "$$cap_elasticsearch_version",
@@ -67,16 +64,10 @@
             "defaultValue": "1",
             "validRegex": "/^([0-9])+$/"
         },{
-            "id": "$$cap_host_port",
-            "label": "Host Port",
-            "defaultValue": "9200",
-            "description": "External port of Elasticsearch exposed by the host.",
-            "validRegex": "/^([0-9])+$/"
-        },{
             "id": "$$cap_container_port",
             "label": "Container TCP Port",
             "defaultValue": "9200",
-            "description": "Internal port for Elasticsearch the container listens to.",
+            "description": "Port of of Elasticsearch to be exposed by the container.",
             "validRegex": "/^([0-9])+$/"
         }
     ]


### PR DESCRIPTION
receipt to add elasticsearch for single and multi node usage.

i'm aware that kibana and logstash (which are mostly used together as ELK-stack) are missing. i would add them as separate receipes as they're not necessarily needed for every node.