### PR TITLE
Add gitlab-runner

### DIFF
--- a/public/v1/apps/gitlab-runner.json
+++ b/public/v1/apps/gitlab-runner.json
@@ -1,0 +1,30 @@
+{
+    "captainVersion": "1",
+    "documentation": "Taken from https://docs.gitlab.com/runner/install/docker.html and https://docs.gitlab.com/runner/register/",
+    "dockerCompose": {
+        "version": "3",
+        "services": {
+          "$$cap_appname": {
+            "image": "gitlab/gitlab-runner:$$cap_gitlab-runner_version",
+            "notExposeAsWebApp": "true",
+            "volumes": [
+              "$$cap_appname-data:/etc/gitlab-runner",
+              "/var/run/docker.sock:/var/run/docker.sock"
+            ],
+            "restart": "always"
+          }
+        }
+    },
+    "instructions": {
+       "start": "GitLab CI/CD is a tool built into GitLab for software development through the continuous methodologies. With this runner, you take your pipelines into your own hand and get unlimited pipeline runtime.",
+        "end": "Head over to https://docs.gitlab.com/runner/register/ to register your newly installed runner. You can run 'docker exec -ti <runner-image-name> /bin/sh' to connect to the newly created container and follow the tutorial."
+    },
+    "variables": [{
+            "id": "$$cap_gitlab-runner_version",
+            "label": "GitLab-Runner Version",
+            "defaultValue": "v11.11.0",
+            "description": "Checkout their docker page for the valid tags https://hub.docker.com/r/gitlab/gitlab-runner/tags",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        }
+    ]
+}

--- a/public/v1/apps/gitlab-runner.json
+++ b/public/v1/apps/gitlab-runner.json
@@ -16,7 +16,7 @@
         }
     },
     "instructions": {
-       "start": "GitLab CI/CD is a tool built into GitLab for software development through the continuous methodologies. With this runner, you take your pipelines into your own hand and get unlimited pipeline runtime.",
+       "start": "GitLab CI/CD is the CI/CD solution integrated into GitLab. With this one-click-app, you receive a self-hosted runner for your pipelines. To enable you to build Docker Images in your pipelines, we mount /var/run/docker.sock into the container of the runner (see https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-socket-binding for more info). As a consequence, this container will have full access to all your other containers. If you don't need this functionality, feel free to manually remove the mounted Docker socket from the volumes.",
         "end": "Head over to https://docs.gitlab.com/runner/register/ to register your newly installed runner. You can run 'docker exec -ti <runner-image-name> /bin/sh' to connect to the newly created container and follow the tutorial."
     },
     "variables": [{


### PR DESCRIPTION
With this One-Click-App, users can easily create their own Gitlab
Runner to get unlimited ci/cd pipelines.

### ☑️ Self Check before Merge

- ☑️ I have tested the template using the method described in README.md thoroughly
- ☑️ I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- ☑️ I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- ☑️ I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- ☑️ Documentation field contains a link to a page with proper explanations on environmental variables, volumes or the docker compose file.
