### PR TITLE
Make sure to use correct data folder for mariadb

### DIFF
--- a/public/v1/apps/mariadb.json
+++ b/public/v1/apps/mariadb.json
@@ -10,7 +10,7 @@
           "CMD [\"--character-set-server=$$cap_charset\", \"--collation-server=$$cap_collation\", \"--skip-character-set-client-handshake\"]"
         ],
         "notExposeAsWebApp": "true",
-        "volumes": ["$$cap_appname-db-data:/var/lib/mariadb"],
+        "volumes": ["$$cap_appname-db-data:/var/lib/mysql"],
         "restart": "always",
         "environment": {
           "MYSQL_ROOT_PASSWORD": "$$cap_db_pass"


### PR DESCRIPTION
The correct data path for mariadb is "/var/lib/mysql". I learned this the hard way. 

See: https://mariadb.com/kb/en/library/default-data-directory-for-mariadb/

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Documentation field contains a link to a page with proper explanations on environmental variables, volumes or the docker compose file.
