### PR TITLE
Add Countly analytics as a one-click app

### DIFF
--- a/public/v2/apps/countly.json
+++ b/public/v2/apps/countly.json
@@ -1,0 +1,21 @@
+{
+    "captainVersion": "2",
+    "documentation": "Taken from https://hub.docker.com/r/countly/countly-server",
+    "dockerCompose": {
+        "version": "3.3",
+        "services": {
+            "$$cap_appname": {
+                "image": "countly/countly-server",
+                "volumes": [
+                    "$$cap_appname-data:/var/lib/mongodb"
+                ],
+                "restart": "always",
+                "environment": {}
+            }
+        }
+    },
+    "instructions": {
+        "start": "Countly. Product Analytics for Mobile, Web, Desktop and IoT | https://count.ly",
+        "end": "Countly is deployed and available as $$cap_appname"
+    }
+}

--- a/public/v2/apps/countly.json
+++ b/public/v2/apps/countly.json
@@ -5,7 +5,7 @@
         "version": "3.3",
         "services": {
             "$$cap_appname": {
-                "image": "countly/countly-server",
+                "image": "countly/countly-server:$$cap_countly_version",
                 "volumes": [
                     "$$cap_appname-data:/var/lib/mongodb"
                 ],

--- a/public/v2/apps/countly.json
+++ b/public/v2/apps/countly.json
@@ -17,5 +17,13 @@
     "instructions": {
         "start": "Countly. Product Analytics for Mobile, Web, Desktop and IoT | https://count.ly",
         "end": "Countly is deployed and available as $$cap_appname"
-    }
+    },
+    "variables": [{
+            "id": "$$cap_countly_version",
+            "label": "What version/tag do you want?",
+            "description": "Go here to see all versions https://hub.docker.com/r/countly/countly-server/tags",
+            "defaultValue": "latest",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        }
+    ]
 }

--- a/public/v2/apps/countly.json
+++ b/public/v2/apps/countly.json
@@ -15,7 +15,7 @@
         }
     },
     "instructions": {
-        "start": "Countly. Product Analytics for Mobile, Web, Desktop and IoT | https://count.ly",
+        "start": "Countly. This will only work over HTTPS, so enable plz :) | Product Analytics for Mobile, Web, Desktop and IoT | https://count.ly",
         "end": "Countly is deployed and available as $$cap_appname"
     },
     "variables": [{


### PR DESCRIPTION
Thank you everyone! Here is a one-click app that is confirmed to work.

This app bootstraps itself (in the same way magento and wordpress do), so there's little need to add env vars.

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Documentation field contains a link to a page with proper explanations on environmental variables, volumes or the docker compose file.
