### PR TITLE
Web server One Click Apps

### DIFF
--- a/public/v2/apps/gostatic.json
+++ b/public/v2/apps/gostatic.json
@@ -1,0 +1,23 @@
+{
+    "captainVersion": "2",
+    "documentation": "https://hub.docker.com/r/pierrezemb/gostatic",
+    "dockerCompose": {
+        "version": "3.3",
+        "services": {
+            "$$cap_appname": {
+                "image": "pierrezemb/gostatic:latest",
+                "volumes": [
+                    "$$cap_appname-data:/srv/http"
+                ],
+                "restart": "always",
+                "environment": {}
+            }
+        }
+    },
+    "instructions": {
+        "start": "A really small and simple one-click static web server app",
+        "end": "gostatic is deployed and available as $$cap_appname"
+    },
+    "variables": []
+
+}

--- a/public/v2/apps/php7.json
+++ b/public/v2/apps/php7.json
@@ -1,0 +1,23 @@
+{
+    "captainVersion": "2",
+    "documentation": "https://hub.docker.com/r/trafex/alpine-nginx-php7",
+    "dockerCompose": {
+        "version": "3.3",
+        "services": {
+            "$$cap_appname": {
+                "image": "trafex/alpine-nginx-php7:latest",
+                "volumes": [
+                    "$$cap_appname-data:/var/www/html"
+                ],
+                "restart": "always",
+                "environment": {}
+            }
+        }
+    },
+    "instructions": {
+        "start": "A one-click PHP-FPM 7.3 web server",
+        "end": "Web server is deployed and available as $$cap_appname"
+    },
+    "variables": []
+
+}


### PR DESCRIPTION
I've noticed that there aren't any one-click applications for serving websites.

I've been using basic captain-definition files, but figured that it'd be good to add them to the One-Click-Apps repository

### ☑️ Self Check before Merge

- [X] I have tested the template using the method described in README.md thoroughly
- [X] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [X] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [X] Documentation field contains a link to a page with proper explanations on environmental variables, volumes or the docker compose file.
