### PR TITLE
Fix strapi host

### DIFF
--- a/public/v2/apps/strapi.json
+++ b/public/v2/apps/strapi.json
@@ -33,7 +33,7 @@
                     "DATABASE_NAME": "strapi",
                     "DATABASE_USERNAME": "root",
                     "DATABASE_PASSWORD": "$$cap_mongo_password",
-                    "HOST": "localhost",
+                    "HOST": "$$cap_appname.$$cap_root_domain",
                     "DATABASE_AUTHENTICATION_DATABASE": "admin"
                 }
             },


### PR DESCRIPTION
This fixes the issue where strapi was redirecting to localhost instead of app url.

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [ ] I have tested the template using the method described in README.md thoroughly
- [ ] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [ ] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [ ] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] Icon is added as a png file to the logos directory.
- [ ] Documentation field contains a link to a page with proper explanations on environmental variables, volumes or the docker compose file.
