### PR TITLE
updated phpmyadmin + file upload limit

### DIFF
--- a/public/v2/apps/phpmyadmin.json
+++ b/public/v2/apps/phpmyadmin.json
@@ -10,21 +10,30 @@
                 "image": "phpmyadmin/phpmyadmin:$$cap_pma_version",
                 "restart": "always",
                 "environment": {
-                    "PMA_ARBITRARY": "1"
+                    "PMA_ARBITRARY": "1",
+                    "UPLOAD_LIMIT": "$$cap_upload_limit"
                 }
             }
         }
     },
     "instructions": {
         "start": "PhpMyAdmin is the most popular web interface for MySQL & MariaDB. Simply install PhpMyAdmin and then select what database you want to connect to.\n\n Enter your PhpMyAdmin Configuration parameters and click on next. It will take about a minute for the process to finish.",
-        "end": "PhpMyAdmin is deployed and available as $$cap_appname"
+        "end": "PhpMyAdmin is deployed and available as $$cap_appname. \n\nNote: Once deployed you can easily change the upload limit file size by modifying the value in the variable in the menu: App Configs>UPLOAD_LIMIT.\n\nIf you need to upload files bigger than 500M you will also need to modify the option: 'client_max_body_size 500m' by clicking in the menu: HTTP Settings>Edit Default Nginx Configurations."
     },
-    "variables": [{
-        "id": "$$cap_pma_version",
-        "label": "PHP My Admin Version Tag",
-        "description": "Check out their Docker page for the valid tags https://hub.docker.com/r/phpmyadmin/phpmyadmin/tags/",
-        "defaultValue": "4.8",
-        "validRegex": "/^([^\\s^\\/])+$/"
-    }]
-
+    "variables": [
+        {
+            "id": "$$cap_upload_limit",
+            "label": "File size upload limit",
+            "description": "It will override the default value for apache and php-fpm inside the container. Default size is 2M",
+            "defaultValue": "2M",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        },
+        {
+            "id": "$$cap_pma_version",
+            "label": "PHP My Admin Version Tag",
+            "description": "Check out their Docker page for the valid tags https://hub.docker.com/r/phpmyadmin/phpmyadmin/tags/",
+            "defaultValue": "5.0.2",
+            "validRegex": "/^([^\\s^\\/])+$/"
+        }
+    ]
 }


### PR DESCRIPTION
First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] Documentation field contains a link to a page with proper explanations on environmental variables, volumes or the docker compose file.

This is just a simple update to the phpmyadmin json, it uses the latest image available 5.0.2 which has support to modify the file size upload limit using a env called UPLAOD_LIMIT. (The default upload limit is 2MiB and can't be easily changed)
