### PR TITLE
Fix typo (deployed Peertube doesn't include '-peertube')

### DIFF
--- a/public/v2/apps/peertube.json
+++ b/public/v2/apps/peertube.json
@@ -65,7 +65,7 @@
     },
     "instructions": {
         "start": "PeerTube is a free, decentralized and federated video platform. (Github : https://github.com/Chocobozzz/PeerTube/)",
-        "end": "Peertube is deployed and available as $$cap_appname-peertube. \n\n IMPORTANT: It will take up to 2 minutes for peertube to be ready. Before that, you might see 502 error page.\n"
+        "end": "Peertube is deployed and available as $$cap_appname. \n\n IMPORTANT: It will take up to 2 minutes for peertube to be ready. Before that, you might see 502 error page.\n"
     },
     "variables": [{
             "id": "$$cap_db_user",


### PR DESCRIPTION
First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] Documentation field contains a link to a page with proper explanations on environmental variables, volumes or the docker compose file.

Just a minor typo.  Deployed Peertube instance is named `$$cap_appname`, not `$$cap_appname-peertube`.