### PR TITLE
MVP: Elastic stack security improvements

### DIFF
--- a/public/v2/apps/elasticsearch.json
+++ b/public/v2/apps/elasticsearch.json
@@ -20,7 +20,10 @@
                     "node.name": "$$cap_appname",
                     "node.master": "$$cap_elasticsearch_node_master",
                     "node.data": "$$cap_elasticsearch_node_data",
-                    "discovery.seed_hosts": "$$cap_elasticsearch_discovery_seed_hosts"
+                    "discovery.seed_hosts": "$$cap_elasticsearch_discovery_seed_hosts",
+                    "xpack.security.enabled":  "$$cap_elasticsearch_enable_security",
+                    "xpack.security.transport.ssl.enabled": "$$cap_elasticsearch_enable_security",
+                    "ELASTIC_PASSWORD":  "$$cap_elasticsearch_password"
                 },
                 "containerHttpPort": "$$cap_container_port"
             }
@@ -79,6 +82,17 @@
             "defaultValue": "9200",
             "description": "Internal port for Elasticsearch the container listens to.",
             "validRegex": "/^([0-9])+$/"
+        },
+        {
+            "id": "$$cap_elasticsearch_enable_security",
+            "label": "Enable elasticsearch security?",
+            "defaultValue": "false",
+            "description": "If this is enabled, and ELASTIC_PASSWORD is provided, your elastic search will be protected by basic auth with use 'elastic'. NOTE: HTTPS needs to be enabled if you chose this option!"
+        },
+        {
+            "id": "$$cap_elasticsearch_password",
+            "label": "ELASTIC_PASSWORD",
+            "description": "To be used if security is enabled."
         }
     ]
 }

--- a/public/v2/apps/kibana.json
+++ b/public/v2/apps/kibana.json
@@ -11,7 +11,9 @@
                     "SERVER_NAME": "$$cap_appname",
                     "KIBANA_DEFAULTAPPID": "$$cap_KIBANA_DEFAULTAPPID",
                     "MONITORING_ENABLED": "$$cap_MONITORING_ENABLED",
-                    "ELASTICSEARCH_HOSTS": "$$cap_ELASTICSEARCH_HOSTS"
+                    "ELASTICSEARCH_HOSTS": "$$cap_ELASTICSEARCH_HOSTS",
+                    "ELASTICSEARCH_PASSWORD": "$$cap_ELASTICSEARCH_PASSWORD",
+                    "ELASTICSEARCH_USERNAME": "$$cap_ELASTICSEARCH_USERNAME"
                 },
                 "image": "docker.elastic.co/kibana/kibana:$$cap_version",
                 "restart": "always"
@@ -46,6 +48,17 @@
             "label": "ELASTICSEARCH_HOSTS",
             "description": "URL of the elasticsearch hosts to use. Please include the http or https in the urls. eg. http://srv-captain--elastic",
             "id": "$$cap_ELASTICSEARCH_HOSTS"
+        },
+        {
+            "label": "ELASTICSEARCH_USERNAME",
+            "defaultValue": "elastic",
+            "description": "To use if your cluster has security enabled. Username is the elasticsearch default 'elastic'",
+            "id": "$$cap_ELASTICSEARCH_USERNAME"
+        },
+        {
+            "label": "ELASTICSEARCH_PASSWORD",
+            "description": "Password of your elastic search cluster if security enabled",
+            "id": "$$cap_ELASTICSEARCH_PASSWORD"
         }
     ]
 }


### PR DESCRIPTION
So... in light of the recent meow attacks - https://arstechnica.com/information-technology/2020/07/more-than-1000-databases-have-been-nuked-by-mystery-meow-attack/

> At the time this post went live, the Shodan computer search site showed that 987 ElasticSearch .. had been nuked by Meow

I was wondering if having the passwords as env variables is worse than having unsecured elastic instances .

**This is a suggestion**. I tried using caprover's http basic auth on elastic, but it doesn't play very well with the rest of the elasticsearch stack (eg. I cannot connect to Kibana, even with `https://user:pass@elasticsearch` as the instance url)

If you feel like this is an edge case, feel free to close this PR

### ☑️ Self Check before Merge

- [ ] I have tested the template using the method described in README.md thoroughly
- [ ] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [ ] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [ ] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] Icon is added as a png file to the logos directory.
