### PR TITLE
Fix broken deployments for Chatwoot

### DIFF
--- a/public/v2/apps/chatwoot.json
+++ b/public/v2/apps/chatwoot.json
@@ -78,14 +78,14 @@
     },
     "instructions": {
         "start": "Open-source customer support saas alternative to Intercom, Drift, Crisp.",
-        "end": "Your Chatwoot instance is now successfully deployed. You can login using test credentials 'john@acme.inc' and '123456' \n\n Refer https://www.chatwoot.com/docs/environment-variables/ for full list of environment variables available. Let us know if you have any queries through hello@chatwoot.com"
+        "end": "Your Chatwoot instance is now successfully deployed. You can create a new account using signup option. \n\n Refer https://www.chatwoot.com/docs/environment-variables/ for full list of environment variables available. Let us know if you have any queries through hello@chatwoot.com"
     },
     "variables": [
         {
             "id": "$$cap_chatwoot_version",
             "label": "Chatwoot Version Tag",
             "description": "https://hub.docker.com/r/chatwoot/chatwoot/tags",
-            "defaultValue": "v1.6.0"
+            "defaultValue": "v1.6.3"
         },
         {
             "id": "$$cap_chatwoot_secret_key_base",


### PR DESCRIPTION
Use v1.6.3 as the default image.

### Known issues for 1.6.3

- Seed data won't be populated in the DB, they would need to create a new account instead of default account. This would be fixed in v1.7.0. For now, I've updated the instructions.

### ☑️ Self Check before Merge

- [ ] I have tested the template using the method described in README.md thoroughly
- [ ] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] Icon is added as a png file to the logos directory.
