### PR TITLE
Update invalid option in environment for Chatwoot

### DIFF
--- a/public/v4/apps/chatwoot.yml
+++ b/public/v4/apps/chatwoot.yml
@@ -25,7 +25,7 @@ services:
     $$cap_appname-web:
         restart: always
         environment:
-            RAIL_ENV: production
+            RAILS_ENV: production
             RAILS_LOG_TO_STDOUT: 'true'
             SECRET_KEY_BASE: $$cap_chatwoot_secret_key_base
             POSTGRES_HOST: srv-captain--$$cap_appname-postgres
@@ -45,7 +45,7 @@ services:
     $$cap_appname-worker:
         restart: always
         environment:
-            RAIL_ENV: production
+            RAILS_ENV: production
             RAILS_LOG_TO_STDOUT: 'true'
             SECRET_KEY_BASE: $$cap_chatwoot_secret_key_base
             POSTGRES_HOST: srv-captain--$$cap_appname-postgres
@@ -66,7 +66,7 @@ caproverOneClickApp:
         - id: $$cap_chatwoot_version
           label: Chatwoot Version Tag
           description: https://hub.docker.com/r/chatwoot/chatwoot/tags
-          defaultValue: v1.6.3
+          defaultValue: v1.7.2
         - id: $$cap_chatwoot_secret_key_base
           label: Chatwoot Secret Key Base
           description: The randomized string which is used to verify the integrity of signed cookies. Please use a string with more than 26 characters


### PR DESCRIPTION
- Update the default environment variables to use RAILS_ENV
- Update the base version to v1.7.2


### ☑️ Self Check before Merge

- [ ] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] Icon is added as a png file to the logos directory.
