### PR TITLE
Wordpress Databases Password Fix

### DIFF
--- a/public/v4/apps/wordpress.yml
+++ b/public/v4/apps/wordpress.yml
@@ -32,7 +32,7 @@ caproverOneClickApp:
         - id: $$cap_db_pass
           label: Database password
           description: ''
-          validRegex: /^([a-zA-Z0-9])+$/
+          validRegex: /^(\w|[^\s"])+$/
         - id: $$cap_wp_version
           label: WordPress Version
           defaultValue: '4.9'

--- a/public/v4/apps/wordpress.yml
+++ b/public/v4/apps/wordpress.yml
@@ -32,7 +32,7 @@ caproverOneClickApp:
         - id: $$cap_db_pass
           label: Database password
           description: ''
-          validRegex: /^(\w|[^\s"])+$/
+          validRegex: /^(\w|[^\s"'\\])+$/
         - id: $$cap_wp_version
           label: WordPress Version
           defaultValue: '4.9'


### PR DESCRIPTION
Allow special symbols in WordPress's databases password field.

the current regex is not allowing the user to put the special character such as @, $  etc.

**current regex status:** https://regex101.com/r/AQHqeO/1 
**modified or fixed regex:** https://regex101.com/r/fwFYSJ/1

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end-users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
