### PR TITLE
Use $$cap_root_domain to help facilitate the easy setup of sentry

### DIFF
--- a/public/v4/apps/sentry.yml
+++ b/public/v4/apps/sentry.yml
@@ -91,7 +91,7 @@ services:
                 - "RUN echo 'mail.use-tls: true' >> /etc/sentry/config.yml"
                 - 'RUN echo ''mail.username: ""'' >> /etc/sentry/config.yml'
                 - 'RUN echo ''system.admin-email: ""'' >> /etc/sentry/config.yml'
-                - 'RUN echo ''system.url-prefix: "$$cap_root_domain"'' >> /etc/sentry/config.yml'
+                - 'RUN echo ''system.url-prefix: "http://$$cap_appname-sentry.$$cap_root_domain"'' >> /etc/sentry/config.yml'
                 - RUN echo '#!/bin/bash' >> ./init.sh
                 - RUN echo 'echo Starting configuration. The App will restart multiple times.' >> ./init.sh
                 - "RUN echo 'echo 1 of 4 : running upgrade' >> ./init.sh"

--- a/public/v4/apps/sentry.yml
+++ b/public/v4/apps/sentry.yml
@@ -91,7 +91,7 @@ services:
                 - "RUN echo 'mail.use-tls: true' >> /etc/sentry/config.yml"
                 - 'RUN echo ''mail.username: ""'' >> /etc/sentry/config.yml'
                 - 'RUN echo ''system.admin-email: ""'' >> /etc/sentry/config.yml'
-                - 'RUN echo ''system.url-prefix: ""'' >> /etc/sentry/config.yml'
+                - 'RUN echo ''system.url-prefix: "$$cap_root_domain"'' >> /etc/sentry/config.yml'
                 - RUN echo '#!/bin/bash' >> ./init.sh
                 - RUN echo 'echo Starting configuration. The App will restart multiple times.' >> ./init.sh
                 - "RUN echo 'echo 1 of 4 : running upgrade' >> ./init.sh"


### PR DESCRIPTION
According to this [comment](https://github.com/caprover/one-click-apps/pull/60#issuecomment-488957376) and this [comment](https://github.com/caprover/one-click-apps/pull/60#issuecomment-521431892), it is now possible to ease the installation of sentry.  
