### PR TITLE
Remove the suffix of "sentry" from the url prefix

### DIFF
--- a/public/v4/apps/sentry.yml
+++ b/public/v4/apps/sentry.yml
@@ -91,7 +91,7 @@ services:
                 - "RUN echo 'mail.use-tls: true' >> /etc/sentry/config.yml"
                 - 'RUN echo ''mail.username: ""'' >> /etc/sentry/config.yml'
                 - 'RUN echo ''system.admin-email: ""'' >> /etc/sentry/config.yml'
-                - 'RUN echo ''system.url-prefix: "http://$$cap_appname-sentry.$$cap_root_domain"'' >> /etc/sentry/config.yml'
+                - 'RUN echo ''system.url-prefix: "http://$$cap_appname.$$cap_root_domain"'' >> /etc/sentry/config.yml'
                 - RUN echo '#!/bin/bash' >> ./init.sh
                 - RUN echo 'echo Starting configuration. The App will restart multiple times.' >> ./init.sh
                 - "RUN echo 'echo 1 of 4 : running upgrade' >> ./init.sh"


### PR DESCRIPTION
Ooops, from #364 I accidentally added the 'sentry' suffix to the app name. Therefore the DSN comes out pointing to the wrong location. I found this out on a recent deploy I just did with the changes here 🤦 .
