### PR TITLE
Upgrade Strapi from beta to 3.5.3

### DIFF
--- a/public/v4/apps/strapi.yml
+++ b/public/v4/apps/strapi.yml
@@ -1,6 +1,6 @@
 captainVersion: 4
 services:
-    $$cap_appname-core:
+    $$cap_appname:
         depends_on:
             - $$cap_appname-mongo
         image: strapi/strapi:$$cap_strapi_version
@@ -12,7 +12,7 @@ services:
             DATABASE_HOST: srv-captain--$$cap_appname-mongo
             DATABASE_PORT: '27017'
             DATABASE_NAME: strapi
-            DATABASE_USERNAME: root
+            DATABASE_USERNAME: strapi
             DATABASE_PASSWORD: $$cap_mongo_password
             DATABASE_AUTHENTICATION_DATABASE: strapi
         caproverExtra:
@@ -22,10 +22,10 @@ services:
         volumes:
             - $$cap_appname-mongo-data:/data/db
             - $$cap_appname-mongo-config:/data/configdb
-        restart: always
+        restart: unless-stopped
         environment:
             MONGO_INITDB_DATABASE: strapi
-            MONGO_INITDB_ROOT_USERNAME: root
+            MONGO_INITDB_ROOT_USERNAME: strapi
             MONGO_INITDB_ROOT_PASSWORD: $$cap_mongo_password
         caproverExtra:
             notExposeAsWebApp: 'true'
@@ -33,33 +33,40 @@ caproverOneClickApp:
     variables:
         - id: $$cap_strapi_version
           label: Strapi Version
-          defaultValue: 3.0.0-beta.18.6
-          description: Check out their page for the valid versions https://hub.docker.com/r/strapi/strapi/tags
+          defaultValue: 3.5.3
+          description: Check out the Docker page for the valid tags https://hub.docker.com/r/strapi/strapi/tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_mongo_version
           label: MongoDB Version
-          defaultValue: '4'
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/library/mongo/tags/
-          validRegex: /^([a-zA-Z0-9])+$/
+          defaultValue: 4.4.4
+          description: Check out the Docker page for the valid tags https://hub.docker.com/r/library/mongo/tags/
+          validRegex: /^([^\s^\/])+$/
         - id: $$cap_mongo_password
           label: MongoDB password
+          defaultValue: $$cap_gen_random_hex(32)
           description: Only use alphanumeric chars.
           validRegex: /^([a-zA-Z0-9])+$/
     instructions:
         start: >-
-            API creation made simple, secure and fast. The most advanced open-source Content Management Framework to build powerful API with no effort. Read more here: https://strapi.io 
+            Strapi is the leading open-source headless CMS. It’s 100% Javascript, fully customizable and developer-first
 
+            Read more here: https://strapi.io
 
-            NOTE: Hardware requirements: 
+            Hardware requirements:
 
-            2GB minimum RAM required
+            2GB RAM required
 
-            1Ghz minimum CPU clock speed
+            1 CPU core (2 is recommended)
+
+            read more on https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/deployment.html#hosting-provider-guides
         end: >-
-            Strapi is deployed and available as $$cap_appname-core 
-             IMPORTANT!! It takes up to 2-5 minutes for Strapi to boot up. You will see a 502 Error until the startup is finished.
+            Strapi is deployed and available as $$cap_appname
 
-            IMPORTANT: You need to add a config file manually to support the correct domain name. See this issue for more details: https://github.com/strapi/strapi-docker/issues/173
+            IMPORTANT: It will take up to 3 minutes for Strapi to be ready. Before that, you will see an 502 error page.
+
+            Note when installing a plugin an error will be displayed. This error message is due to a restart on plugin installation.
+
+            This behaviour is normal. Refresh the page after few seconds (502 can happen if you refresh too fast).
     displayName: ''
     isOfficial: true
     description: The Open source Headless CMS Front-End Developers love. Manage your content. Distribute it anywhere


### PR DESCRIPTION
Upgrade strapi. 
Upgrade mongodb dependencies. 
Remove the root user for mongo to secure the database. 
Add generated mongoDB password to help users


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
