### PR TITLE
Upgrade nextcloud from 19.0.0 to 21.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/*
 node_modules
 .DS_Store
+.idea/

--- a/public/v4/apps/nextcloud.yml
+++ b/public/v4/apps/nextcloud.yml
@@ -56,7 +56,7 @@ caproverOneClickApp:
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_mariadb_version
           label: MariaDB (database) version
-          defaultValue: 10.5.3
+          defaultValue: 10.5.9
           description: Check out their Docker page for the valid tags https://hub.docker.com/_/mariadb?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_db_pass

--- a/public/v4/apps/nextcloud.yml
+++ b/public/v4/apps/nextcloud.yml
@@ -38,8 +38,6 @@ services:
             NEXTCLOUD_ADMIN_USER: $$cap_admin_user
             NEXTCLOUD_ADMIN_PASSWORD: $$cap_admin_pass
             NEXTCLOUD_TRUSTED_DOMAINS: $$cap_appname.$$cap_root_domain
-        caproverExtra:
-            containerHttpPort: '8080'
     $$cap_appname-cron:
         depends_on:
             - $$cap_appname-db

--- a/public/v4/apps/nextcloud.yml
+++ b/public/v4/apps/nextcloud.yml
@@ -105,7 +105,14 @@ caproverOneClickApp:
             If you set the cors sections to https, please enable https on your app. If you do not activate it you will have an error.
 
 
-            For better performances and compliance, you can add "add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;" below "proxy_set_header X-Forwarded-Proto $scheme;" into the nginx configuration.
+            For better performances and compliance, click on "edit default nginx configuration" button then
+            below "proxy_set_header X-Forwarded-Proto $scheme;"
+            add "add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;"  into the nginx configuration.
+
+            You can see HSTS parts of the nextcloud security documentation https://docs.nextcloud.com/server/21/admin_manual/installation/harden_server.html for further informations
+
+
+            You can also scan your nextcloud instance on https://scan.nextcloud.com/
     displayName: nextcloud
     isOfficial: true
     description: Nextcloud is a suite of client-server software for creating and using file hosting services

--- a/public/v4/apps/nextcloud.yml
+++ b/public/v4/apps/nextcloud.yml
@@ -13,9 +13,16 @@ services:
             MYSQL_PASSWORD: $$cap_db_pass
         caproverExtra:
             notExposeAsWebApp: 'true'
+    $$cap_appname-redis:
+        documentation: Taken from https://github.com/nextcloud/docker/blob/master/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
+        image: redis:$$cap_redis_version
+        restart: always
+        caproverExtra:
+            notExposeAsWebApp: 'true'
     $$cap_appname:
         depends_on:
             - $$cap_appname-db
+            - $$cap_appname-redis
         documentation: Taken from https://hub.docker.com/_/nextcloud
         image: nextcloud:$$cap_nextcloud_version
         volumes:
@@ -27,14 +34,18 @@ services:
             MYSQL_USER: $$cap_db_user
             MYSQL_PASSWORD: $$cap_db_pass
             MYSQL_HOST: srv-captain--$$cap_appname-db
+            REDIS_HOST: srv-captain--$$cap_appname-redis
             NEXTCLOUD_ADMIN_USER: $$cap_admin_user
             NEXTCLOUD_ADMIN_PASSWORD: $$cap_admin_pass
             NEXTCLOUD_TRUSTED_DOMAINS: $$cap_appname.$$cap_root_domain
+        caproverExtra:
+            containerHttpPort: '8080'
     $$cap_appname-cron:
         depends_on:
             - $$cap_appname-db
+            - $$cap_appname-redis
             - $$cap_appname
-        documentation: https://github.com/nextcloud/docker/blob/master/.examples/docker-compose/insecure/mariadb-cron-redis/apache/docker-compose.yml
+        documentation: https://github.com/nextcloud/docker/blob/master/.examples/docker-compose/with-nginx-proxy/mariadb-cron-redis/apache/docker-compose.yml
         restart: always
         volumes:
             - $$cap_appname-data:/var/www/html
@@ -47,27 +58,33 @@ caproverOneClickApp:
     variables:
         - id: $$cap_nextcloud_version
           label: NextCloud Version
-          defaultValue: 19.0.0
+          defaultValue: 21.0.1
           description: >-
-              Check out their Docker page for the valid tags https://hub.docker.com/r/library/nextcloud/tags/
+              Check out their Docker page for the valid tags https://hub.docker.com/_/nextcloud?tab=tags
 
 
               Do not use fpm versions.
+          validRegex: /^((?!fpm)\S)+$/
+        - id: $$cap_redis_version
+          label: Redis Version
+          defaultValue: 6.2.2
+          description: Check out their Docker page for the valid tags https://hub.docker.com/_/redis?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_mariadb_version
           label: MariaDB (database) version
           defaultValue: 10.5.9
           description: Check out their Docker page for the valid tags https://hub.docker.com/_/mariadb?tab=tags
           validRegex: /^([^\s^\/])+$/
-        - id: $$cap_db_pass
-          label: database password
-          description: Password for the database user and root using mysql.
-          validRegex: /.{1,}/
         - id: $$cap_db_user
           label: database user
           defaultValue: nextcloud
           description: Username for the database using mysql.
           validRegex: /^([a-zA-Z0-9])+$/
+        - id: $$cap_db_pass
+          label: database password
+          defaultValue: $$cap_gen_random_hex(32)
+          description: Password for the database user and root using mysql.
+          validRegex: /.{1,}/
         - id: $$cap_admin_user
           label: admin name
           defaultValue: admin
@@ -76,7 +93,7 @@ caproverOneClickApp:
         - id: $$cap_admin_pass
           label: admin password
           description: Password for the Nextcloud admin user.
-          validRegex: /.{1,}/
+          validRegex: /.{8,}/
         - id: $$cap_http_https_cors
           label: Protocol of proxy
           defaultValue: https


### PR DESCRIPTION
Upgrading nextcloud from 19 to last version (21.0.1)
Upgrading mariadb from 10.5.3 to last version (10.5.9)
Adding a redis cache to improve performances

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.

I'm using this version on my server.
The server works, nextcloud report says it's fine, all my extensions too.
fits with all my usages but I do not tried all extensions (to many extensions on the market)