### PR TITLE
allow more than one domain on nextcloud 

### DIFF
--- a/public/v4/apps/nextcloud.yml
+++ b/public/v4/apps/nextcloud.yml
@@ -37,7 +37,7 @@ services:
             REDIS_HOST: srv-captain--$$cap_appname-redis
             NEXTCLOUD_ADMIN_USER: $$cap_admin_user
             NEXTCLOUD_ADMIN_PASSWORD: $$cap_admin_pass
-            NEXTCLOUD_TRUSTED_DOMAINS: $$cap_appname.$$cap_root_domain
+            NEXTCLOUD_TRUSTED_DOMAINS: $$cap_appname.$$cap_root_domain $$cap_hostnames
     $$cap_appname-cron:
         depends_on:
             - $$cap_appname-db
@@ -97,6 +97,9 @@ caproverOneClickApp:
           defaultValue: https
           description: Choose either http or https. cors configuration to login are set by the docker image, if you do not set this same as your proxy configuration, login will fail
           validRegex: /^http[s]?$/
+        - id: $$cap_hostnames
+          label: hostnames
+          description: Add all your additional hostnames where nextcloud will be exposed separated by space char. After first run, this variables are not reloaded by nextcloud and you will have to change the configuration according to the nextcloud's documentation.
     instructions:
         start: A safe home for all your data. Access & share your files, calendars, contacts, mail & more from any device, on your terms. http://Nextcloud.com
         end: >-


### PR DESCRIPTION
nextcloud seems to ignore trusted domains after reboot to use the generated configuration file
to help caprover user I added a "more domain" option

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
