### PR TITLE
Remove smtp_user regex validation from Penpot

### DIFF
--- a/public/v4/apps/penpot.yml
+++ b/public/v4/apps/penpot.yml
@@ -128,7 +128,6 @@ caproverOneClickApp:
         - id: $$cap_smtp_username
           label: SMTP username
           defaultValue: user@example.com
-          validRegex: /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
         - id: $$cap_smtp_password
           label: SMTP password
           defaultValue:


### PR DESCRIPTION
The regex validation breaks certain email delivery services, as they don't simply use mail addresses.

AFAIK, there is no limitation on SMTP usernames, when it comes to authentication.

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
