### PR TITLE
change default database charset for wallabag

### DIFF
--- a/public/v4/apps/wallabag.yml
+++ b/public/v4/apps/wallabag.yml
@@ -16,6 +16,7 @@ services:
             SYMFONY__ENV__DATABASE_PASSWORD: $$cap_mariadb-pass
             SYMFONY__ENV__SECRET: $$cap_gen_random_hex(30)
             SYMFONY__ENV__DOMAIN_NAME: https://$$cap_appname.$$cap_root_domain
+            SYMFONY__ENV__DATABASE_CHARSET: utf8mb4
         volumes:
             - $$cap_appname-images:/var/www/wallabag/web/assets/images
     # MariaDB


### PR DESCRIPTION
utf8 delivers several issues with multiple sites (Invalid datetime format for example)
The recommendation from wallabag is to use utf8mb4 as mentioned here: https://github.com/wallabag/wallabag/issues/5116 and here: https://github.com/wallabag/wallabag/issues/4764

The default setup of wallabag in caprover uses utf8, adding this env variable solves the issue even for existing installs.

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
