### PR TITLE
Fix docker hub ref for firefly

### DIFF
--- a/public/v4/apps/firefly-iii.yml
+++ b/public/v4/apps/firefly-iii.yml
@@ -47,7 +47,7 @@ caproverOneClickApp:
         - id: $$cap_firefly_version
           label: Firefly Version Tag
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/fireflyiii/core/tags
-          defaultValue: release-5.3.0
+          defaultValue: version-5.5.13
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_firefly_site-owner
           label: Firefly Site Owner Mail

--- a/public/v4/apps/firefly-iii.yml
+++ b/public/v4/apps/firefly-iii.yml
@@ -1,7 +1,7 @@
 captainVersion: 4
 services:
     $$cap_appname:
-        image: jc5x/firefly-iii:$$cap_firefly_version
+        image: fireflyiii/core:$$cap_firefly_version
         volumes:
             - $$cap_appname-export:/var/www/firefly-iii/storage/export
             - $$cap_appname-upload:/var/www/firefly-iii/storage/upload
@@ -46,7 +46,7 @@ caproverOneClickApp:
           validRegex: /.{1,}/
         - id: $$cap_firefly_version
           label: Firefly Version Tag
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/jc5x/firefly-iii/tags
+          description: Check out their Docker page for the valid tags https://hub.docker.com/r/fireflyiii/core/tags
           defaultValue: release-5.3.0
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_firefly_site-owner


### PR DESCRIPTION
First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.


The official docker hub image for Firefly III has moved -- this PR fixes the ref.