### PR TITLE
Fixed db name

### DIFF
--- a/public/v4/apps/yagpdb.yml
+++ b/public/v4/apps/yagpdb.yml
@@ -14,7 +14,7 @@ services:
             YAGPDB_HOST: $$cap_appname.$$cap_root_domain
             YAGPDB_PQHOST: srv-captain--$$cap_appname-postgres
             YAGPDB_PQUSERNAME: yagpdb
-            YAGPDB_PQDB: yagpdb_prod
+            YAGPDB_PQDB: yagpdb_production
             YAGPDB_PQPASSWORD: $$cap_postgres_password
             YAGPDB_REDIS: srv-captain--$$cap_appname-redis:6379
         volumes:


### PR DESCRIPTION
Fixed a small typo where the database name was set to `yagpdb_prod` instead of `yagpdb_production` like in postgres