### PR TITLE
Update chatwoot default version to v1.20.0

### DIFF
--- a/public/v4/apps/chatwoot.yml
+++ b/public/v4/apps/chatwoot.yml
@@ -34,6 +34,7 @@ services:
             POSTGRES_PASSWORD: $$cap_chatwoot_postgres_password
             REDIS_URL: redis://srv-captain--$$cap_appname-redis:6379
             REDIS_PASSWORD: $$cap_chatwoot_redis_password
+            INSTALLATION_ENV: caprover
         caproverExtra:
             containerHttpPort: '3000'
             dockerfileLines:
@@ -54,6 +55,7 @@ services:
             POSTGRES_PASSWORD: $$cap_chatwoot_postgres_password
             REDIS_URL: redis://srv-captain--$$cap_appname-redis:6379
             REDIS_PASSWORD: $$cap_chatwoot_redis_password
+            INSTALLATION_ENV: caprover
         caproverExtra:
             dockerfileLines:
                 - FROM chatwoot/chatwoot:$$cap_chatwoot_version
@@ -66,7 +68,7 @@ caproverOneClickApp:
         - id: $$cap_chatwoot_version
           label: Chatwoot Version Tag
           description: Choose the latest version from https://hub.docker.com/r/chatwoot/chatwoot/tags
-          defaultValue: v1.13.1
+          defaultValue: v1.20.0
         - id: $$cap_chatwoot_secret_key_base
           label: Chatwoot Secret Key Base
           description: The randomized string which is used to verify the integrity of signed cookies. Please use a string with more than 26 characters


### PR DESCRIPTION

### Changelog
- Update chatwoot default version to the latest release `v1.20.0`
- Add `INSTALLATION_ENV` env variable

Ref: ref: https://github.com/chatwoot/chatwoot/releases/tag/v1.20.0

Fixes: https://github.com/chatwoot/chatwoot/issues/3172

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
