### PR TITLE
Fix port label typo

### DIFF
--- a/public/v4/apps/ghost-only.yml
+++ b/public/v4/apps/ghost-only.yml
@@ -38,7 +38,7 @@ caproverOneClickApp:
         - description: Maria DB port
           defaultValue: '3306'
           id: $$cap_mariadb_port_number
-          label: MariaDB user
+          label: MariaDB port
         - description: Database name
           defaultValue: ghost
           id: $$cap_ghost_database_name


### PR DESCRIPTION
Fix the typo in one of the labels of ghost-only.

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
