### PR TITLE
Fixed package.json formatter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ To create your own repository:
 - Run `npm run validate_apps` 
 - Run `npm run build` 
 - Now you can host the static content placed in `./dist` directory anywhere you want, the official repo uses github pages to publish the content. Make sure to update [CNAME](https://github.com/caprover/one-click-apps/blob/master/public/CNAME) to your own URL if you decide to do so.
+
+Here is a good example: [Skayo's CapRover One-Click-Apps](https://github.com/Skayo/CapRover-One-Click-Apps)

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "One Click App Repository for CapRover",
   "scripts": {
-    "formatter": "prettier --check './public/**/*.(json|yml)'",
-    "formatter-write": "prettier --write './public/**/*.(json|yml)'",
+    "formatter": "prettier --check \"./public/**/*.(json|yml)\"",
+    "formatter-write": "prettier --write \"./public/**/*.(json|yml)\"",
     "build": "rm -rf ./dist/ && mkdir -p dist && node ./scripts/build_one_click_apps.js && node ./scripts/build_one_click_apps_from_v4.js",
     "validate_apps": "node ./scripts/validate_apps.js",
     "publish": "npm run build && ./scripts/publish-from-actions.sh"


### PR DESCRIPTION
The script didn't work with single quotes.
When I ran the script, I got:
```
'yml)'' is not recognized as an internal or external command
```
Using double quotes works, tho.
Maybe it's just an issue on Windows, but I checked and most people use double quotes for this exact prettier command.

Also I have added a link to the README for a custom one-click-app repository example. I can remove it again if you don't want it.