### PR TITLE
Update chatwoot default version to v2.0.0

### DIFF
--- a/public/v4/apps/chatwoot.yml
+++ b/public/v4/apps/chatwoot.yml
@@ -68,7 +68,7 @@ caproverOneClickApp:
         - id: $$cap_chatwoot_version
           label: Chatwoot Version Tag
           description: Choose the latest version from https://hub.docker.com/r/chatwoot/chatwoot/tags
-          defaultValue: v1.20.0
+          defaultValue: v2.0.0
         - id: $$cap_chatwoot_secret_key_base
           label: Chatwoot Secret Key Base
           description: The randomized string which is used to verify the integrity of signed cookies. Please use a string with more than 26 characters


### PR DESCRIPTION
- Update chatwoot default version to the next major version

ref: https://github.com/chatwoot/chatwoot/releases/tag/v2.0.0

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
