### PR TITLE
Remove maxmind container from Plausible

### DIFF
--- a/public/v4/apps/plausible.yml
+++ b/public/v4/apps/plausible.yml
@@ -37,7 +37,7 @@ services:
         caproverExtra:
             containerHttpPort: '8000'
             dockerfileLines:
-                - FROM plausible/analytics:v1.1.1
+                - FROM plausible/analytics:$$cap_PLAUSIBLE_VERSION
                 - CMD ["sh", "-c", "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run"]
         environment:
             ADMIN_USER_EMAIL: $$cap_ADMIN_USER_EMAIL
@@ -93,6 +93,11 @@ caproverOneClickApp:
         - description: This is the password for logging into the SMTP host. Please change it according to your host.
           id: $$cap_RELAY_PASSWORD
           label: RELAY_PASSWORD
+          validRegex: /^([^\s^\/])+$/
+        - description: The version of Plausible docker image (from https://hub.docker.com/r/plausible/analytics/tags eg. v1 or v1.4)
+          id: $$cap_PLAUSIBLE_VERSION
+          label: PLAUSIBLE VERSION 
+          defaultValue: v1
           validRegex: /^([^\s^\/])+$/
     instructions:
         start: >-

--- a/public/v4/apps/plausible.yml
+++ b/public/v4/apps/plausible.yml
@@ -96,17 +96,17 @@ caproverOneClickApp:
           validRegex: /^([^\s^\/])+$/
         - description: The version of Plausible docker image (from https://hub.docker.com/r/plausible/analytics/tags eg. v1 or v1.4)
           id: $$cap_PLAUSIBLE_VERSION
-          label: PLAUSIBLE VERSION
+          label: PLAUSIBLE_VERSION
           defaultValue: v1
           validRegex: /^([^\s^\/])+$/
         - description: Clickhouse version (from https://hub.docker.com/r/yandex/clickhouse-server/tags, eg 21.12.2.17)
           id: $$cap_CLICKHOUSE_VERSION
-          label: CLICKHOUSE VERSION
+          label: CLICKHOUSE_VERSION
           defaultValue: 21.3.2.5
           validRegex: /^([^\s^\/])+$/
         - description: Postgres version (from https://hub.docker.com/_/postgres?tab=tags, eg 12 or 12-alpine)
           id: $$cap_POSTGRES_VERSION
-          label: POSTGRES VERSION
+          label: POSTGRES_VERSION
           defaultValue: 12-alpine
           validRegex: /^([^\s^\/])+$/
     instructions:

--- a/public/v4/apps/plausible.yml
+++ b/public/v4/apps/plausible.yml
@@ -118,9 +118,15 @@ caproverOneClickApp:
             - https://hub.docker.com/r/bytemark/smtp, that allows linked containers to send outgoing email
             - official PostgreSQL image based on Alpine Linux and
             - ClickHouse image https://hub.docker.com/r/yandex/clickhouse-server.
+            This version includes an open source geoip database (db-ip). If you would like to use Maxmind db,
+            You will need to mount a volume and an additional container to update the database. You can use this docker
+            compose file for reference: https://github.com/plausible/hosting/blob/master/geoip/docker-compose.geoip.yml
         end: >-
             Plausible.io is deployed and available as $$cap_appname.
             In case you add a new domain to your application, remember to set the environment variable BASE_URL accordingly.
+
+            See https://github.com/plausible/analytics/blob/master/config/runtime.exs for all configurable
+            environment variables, for features like Google search, postmark, and slack integrations.
 
             IMPORTANT: It will take up to 2 minutes for Plausible to be ready. Before that, you might see 502 error page.
     displayName: Plausible

--- a/public/v4/apps/plausible.yml
+++ b/public/v4/apps/plausible.yml
@@ -29,16 +29,6 @@ services:
         caproverExtra:
             notExposeAsWebApp: 'true'
 
-    $$cap_appname-geoip:
-        image: maxmindinc/geoipupdate:v4.5
-        environment:
-            GEOIPUPDATE_ACCOUNT_ID: $$cap_GEOIPUPDATE_ACCOUNT_ID
-            GEOIPUPDATE_LICENSE_KEY: $$cap_GEOIPUPDATE_LICENSE_KEY
-            GEOIPUPDATE_EDITION_IDS: GeoLite2-Country
-            GEOIPUPDATE_FREQUENCY: 168
-        volumes:
-            - $$cap_appname-geoip-data:/usr/share/GeoIP
-
     $$cap_appname:
         depends_on:
             - $$cap_appname-postgres
@@ -63,9 +53,6 @@ services:
             MAILER_EMAIL: $$cap_RELAY_USERNAME
             SMTP_HOST_ADDR: srv-captain--$$cap_appname-mail
             SMTP_HOST_PORT: '25'
-            GEOLITE2_COUNTRY_DB: '/geoip/GeoLite2-Country.mmdb'
-        volumes:
-            - $$cap_appname-geoip-data:/geoip
 
 caproverOneClickApp:
     variables:
@@ -107,14 +94,6 @@ caproverOneClickApp:
           id: $$cap_RELAY_PASSWORD
           label: RELAY_PASSWORD
           validRegex: /^([^\s^\/])+$/
-        - description: Provide your own ACCOUNT_ID, you can sign-up at https://www.maxmind.com/en/geoip2-services-and-databases
-          id: $$cap_GEOIPUPDATE_ACCOUNT_ID
-          label: GEOIPUPDATE_ACCOUNT_ID
-          validRegex: /^([^\s^\/])+$/
-        - description: Provide the corresponding License Key for your own ACCOUNT_ID.
-          id: $$cap_GEOIPUPDATE_LICENSE_KEY
-          label: GEOIPUPDATE_LICENSE_KEY
-          validRegex: /^([^\s^\/])+$/
     instructions:
         start: >-
             Plausible is a lightweight and open-source website analytics tool.
@@ -122,9 +101,8 @@ caproverOneClickApp:
             This one click app uses the:
             - official image from https://hub.docker.com/r/plausible/analytics
             - https://hub.docker.com/r/bytemark/smtp, that allows linked containers to send outgoing email
-            - official PostgreSQL image based on Alpine Linux
-            - ClickHouse image https://hub.docker.com/r/yandex/clickhouse-server, an open-source column-oriented database
-            - official image from https://hub.docker.com/r/maxmindinc/geoipupdate, the well known MaxMind GeoIP Update Tool.
+            - official PostgreSQL image based on Alpine Linux and
+            - ClickHouse image https://hub.docker.com/r/yandex/clickhouse-server.
         end: >-
             Plausible.io is deployed and available as $$cap_appname.
             In case you add a new domain to your application, remember to set the environment variable BASE_URL accordingly.

--- a/public/v4/apps/plausible.yml
+++ b/public/v4/apps/plausible.yml
@@ -13,7 +13,7 @@ services:
             notExposeAsWebApp: 'true'
 
     $$cap_appname-postgres:
-        image: postgres:12-alpine
+        image: postgres:$$cap_POSTGRES_VERSION
         volumes:
             - $$cap_appname-postgres-data:/var/lib/postgresql/data
         environment:
@@ -23,7 +23,7 @@ services:
             notExposeAsWebApp: 'true'
 
     $$cap_appname-clickhouse:
-        image: yandex/clickhouse-server:20.8.5.45
+        image: yandex/clickhouse-server:$$cap_CLICKHOUSE_VERSION
         volumes:
             - $$cap_appname-clickhouse-data:/var/lib/clickhouse
         caproverExtra:
@@ -99,10 +99,20 @@ caproverOneClickApp:
           label: PLAUSIBLE VERSION 
           defaultValue: v1
           validRegex: /^([^\s^\/])+$/
+        - description: Clickhouse version (from https://hub.docker.com/r/yandex/clickhouse-server/tags, eg 21.12.2.17)
+          id: $$cap_CLICKHOUSE_VERSION
+          label: CLICKHOUSE VERSION 
+          defaultValue: 21.3.2.5
+          validRegex: /^([^\s^\/])+$/
+        - description: Postgres version (from https://hub.docker.com/_/postgres?tab=tags, eg 12 or 12-alpine)
+          id: $$cap_POSTGRES_VERSION
+          label: POSTGRES VERSION
+          defaultValue: 12-alpine
+          validRegex: /^([^\s^\/])+$/
     instructions:
         start: >-
             Plausible is a lightweight and open-source website analytics tool.
-            It doesn’t use cookies and is fully compliant with GDPR, CCPA and PECR. Made and hosted in the EU.
+            It doesn't use cookies and is fully compliant with GDPR, CCPA and PECR. Made and hosted in the EU.
             This one click app uses the:
             - official image from https://hub.docker.com/r/plausible/analytics
             - https://hub.docker.com/r/bytemark/smtp, that allows linked containers to send outgoing email

--- a/public/v4/apps/plausible.yml
+++ b/public/v4/apps/plausible.yml
@@ -96,12 +96,12 @@ caproverOneClickApp:
           validRegex: /^([^\s^\/])+$/
         - description: The version of Plausible docker image (from https://hub.docker.com/r/plausible/analytics/tags eg. v1 or v1.4)
           id: $$cap_PLAUSIBLE_VERSION
-          label: PLAUSIBLE VERSION 
+          label: PLAUSIBLE VERSION
           defaultValue: v1
           validRegex: /^([^\s^\/])+$/
         - description: Clickhouse version (from https://hub.docker.com/r/yandex/clickhouse-server/tags, eg 21.12.2.17)
           id: $$cap_CLICKHOUSE_VERSION
-          label: CLICKHOUSE VERSION 
+          label: CLICKHOUSE VERSION
           defaultValue: 21.3.2.5
           validRegex: /^([^\s^\/])+$/
         - description: Postgres version (from https://hub.docker.com/_/postgres?tab=tags, eg 12 or 12-alpine)


### PR DESCRIPTION
## This is a heavily opinionated PR. Feel free to close. Rational in the description

- Since early 2020 Maxmind changed their licensing. This means that if you want to deploy Plausible for anything commercial, or in support of anything commercial, you need to pay.

- Since then Plausible started shipping with scripts to fetch data from a free source (db-ip): https://github.com/plausible/analytics/blob/1dba113e2fe5fb3593c56fa6994f6d088d3fec80/config/runtime.exs#L110

- This app has mandatory fields for Maxmind api call, although it is not strictly necessary anymore

- This makes me think it's better to default to a free installation of plausible, and allow users to add the maxmind container if they wish to do so with a custom template.

- I tried check if there's any way to add / remove containers with conditional logic, but I couldn't find anything for that. This would be a great use case for basic `if/else` templating in the apps :)


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
