### PR TITLE
Fix typo in qBittorrent

### DIFF
--- a/public/v4/apps/qbittorrent.yml
+++ b/public/v4/apps/qbittorrent.yml
@@ -34,7 +34,7 @@ caproverOneClickApp:
           validRegex: /\d/
         - id: $$cap_path_to_downloads
           label: Path to downloads folder
-          defaultValue: qbittorent-downloads
+          defaultValue: qbittorrent-downloads
           description: Path to downloads folder where u want to save the downloaded torrents. You can mention an existing directory here too. Eg. /home/user/downloads/
           validRegex: /.{1,}/
     instructions:

--- a/public/v4/apps/qbittorrent.yml
+++ b/public/v4/apps/qbittorrent.yml
@@ -35,7 +35,7 @@ caproverOneClickApp:
         - id: $$cap_path_to_downloads
           label: Path to downloads folder
           defaultValue: qbittorrent-downloads
-          description: Path to downloads folder where u want to save the downloaded torrents. You can mention an existing directory here too. Eg. /home/user/downloads/
+          description: Path to downloads folder where you want to save the downloaded torrents. You can mention an existing directory here too. Eg. /home/user/downloads/
           validRegex: /.{1,}/
     instructions:
         start: >-


### PR DESCRIPTION
Fixes a typo in the qBittorrent download folder path

Edit: noticed another typo