### PR TITLE
Update paperless-ng.yml for proper gotenberg support

### DIFF
--- a/public/v4/apps/paperless-ng.yml
+++ b/public/v4/apps/paperless-ng.yml
@@ -98,7 +98,7 @@ services:
 
     # gotenberg
     $$cap_appname-gotenberg:
-        image: thecodingmachine/gotenberg
+        image: thecodingmachine/gotenberg:6
         restart: unless-stopped
         environment:
             DISABLE_GOOGLE_CHROME: 1


### PR DESCRIPTION
Only version 6 of gotenberg works properly with paperless-ng. If the image name is left undefined (as it is right now) it downloads and deploys version 7.5, which gives a 404 error when called by paperless-ng. Setting it to gotenberg:6 fixes the issue.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
