### PR TITLE
Made two minor corrections to the existing Percona Server app.

### DIFF
--- a/public/v4/apps/percona.yml
+++ b/public/v4/apps/percona.yml
@@ -17,7 +17,7 @@ caproverOneClickApp:
         - id: $$cap_percona_version
           label: Percona Version
           defaultValue: 'ps-8.0'
-          description: Check out their Docker page for the valid tags https://hub.docker.com/_/mariadb?tab=tags
+          description: Check out their Docker page for the valid tags https://hub.docker.com/_/percona
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_db_pass
           label: Percona Root password

--- a/public/v4/apps/percona.yml
+++ b/public/v4/apps/percona.yml
@@ -1,9 +1,9 @@
 captainVersion: 4
 services:
-    $$cap_appname-percona:
+    $$cap_appname:
         image: percona:$$cap_percona_version
         volumes:
-            - $$cap_appname-percona-data:/var/lib/mysql
+            - $$cap_appname-data:/var/lib/mysql
         restart: always
         environment:
             MYSQL_ROOT_PASSWORD: $$cap_db_pass
@@ -34,7 +34,7 @@ caproverOneClickApp:
           defaultValue: utf8mb4_unicode_ci
     instructions:
         start: "Percona Server for MySQL is a fork of the MySQL relational database management system created by Percona. It aims to retain close compatibility to the official MySQL releases, while focusing on performance and increased visibility into server operations. Also included in Percona Server is XtraDB, Percona's fork of the InnoDB Storage Engine."
-        end: "Percona is deployed and available as srv-captain--$$cap_appname-percona:3306 to other apps. For example with NodeJS, you do 'var con = mysql.createConnection({ host: 'srv-captain--$$cap_appname-percona', user: 'root', password: '*********' });'"
+        end: "Percona is deployed and available as srv-captain--$$cap_appname:3306 to other apps. For example with NodeJS, you do 'var con = mysql.createConnection({ host: 'srv-captain--$$cap_appname', user: 'root', password: '*********' });'"
     displayName: Percona Server
     isOfficial: true
     description: Percona Server for MySQL is a fork of the MySQL relational database management system created by Percona.


### PR DESCRIPTION
First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [n/a] Icon is added as a png file to the logos directory.

---
The relevant changes are fairly self-explanatory from the commit comments, but just to expand on them a bit:

1. While deploying an instance of Percona on my server, I noticed the Docker Hub link for the available tags was pointing to the MariaDB page rather than the relevant Percona tags, so I simply corrected the URL.
2. Removed the redundant service name from the user-defined app name. 

Quick question on this point: Am I missing a good reason for naming things like this, or is it just a differing preference? I have encountered this particular way of labeling services so many times now that I am not sure if it's intentional, or if it's because folks aren't aware that just `$$cap_appname` by itself is acceptable (or maybe others don't dwell on such small matters), but the `$$cap_appname` in the original file was `$cap_appname-percona`, so when I initially deployed the app, having named my instance "percona", what got deployed was `percona-percona.domain.tld`, which is unnecessary and frequently requires a convoluted process to correct. 

My position is that if one wants the service's name appended onto the user-defined name, they can simply type it into the app name field manually, there's no reason for this to be hard-coded into the template. That said--@githubsaturn if you have a specific preference one way or the other, I will adhere to it moving forward. 
