### PR TITLE
Update FileRun to latest version [broken image, fails to deploy]

### DIFF
--- a/public/v4/apps/filerun.yml
+++ b/public/v4/apps/filerun.yml
@@ -1,7 +1,7 @@
 captainVersion: 4
 services:
     $$cap_appname:
-        image: afian/filerun:$$cap_wp_version
+        image: filerun/filerun:$$cap_wp_version
         volumes:
             - $$cap_appname-html:/var/www/html
             - $$cap_appname-userfiles:/user-files
@@ -39,8 +39,8 @@ caproverOneClickApp:
           validRegex: /.{1,}/
         - id: $$cap_wp_version
           label: Filerun Version.
-          defaultValue: ''
-          description: Use 'latest' tag for normal installation. If you wish to have LibreOffice included, use 'libreoffice' tag. Note that LibreOffice is considerably larger in disk size and memory usage. Check out their Docker page for the valid tags https://hub.docker.com/r/afian/filerun/tags
+          defaultValue: 'latest'
+          description: Use 'latest' tag for normal installation. Check out their Docker page for the valid tags https://hub.docker.com/r/filerun/filerun/tags
           validRegex: /^([^\s^\/])+$/
     instructions:
         start: >-
@@ -60,4 +60,4 @@ caproverOneClickApp:
     displayName: FileRun - No DB
     isOfficial: true
     description: FileRun is a self-hosted Google Drive alternative. It is a full featured web based file manager with an easy to use user interface.
-    documentation: Taken from https://hub.docker.com/r/afian/filerun/.
+    documentation: Taken from https://hub.docker.com/r/filerun/filerun/.


### PR DESCRIPTION
Old image no longer exists (therefore this one click app fails to deploy) as it has been moved to FileRun's own DockerHub account and LibreOffice isn't an option anymore. I am using the latest tag, for two reasons: 1) it's the same as it has been before already 2) there are no tags besides latest and arm32/64.

### ☑️ Self Check before Merge

- [X] I have tested the template using the method described in README.md thoroughly
- [X] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [ ] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [X] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [X] Icon is added as a png file to the logos directory.
