### PR TITLE
Adding TZ Env to ChadBurn Captain file

### DIFF
--- a/public/v4/apps/chadburn.yml
+++ b/public/v4/apps/chadburn.yml
@@ -5,6 +5,8 @@ services:
         image: ghcr.io/premoweb/chadburn:$$cap_version
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
+        environment:
+            TZ: '$$cap_tz'
         caproverExtra:
             notExposeAsWebApp: 'true'
 caproverOneClickApp:


### PR DESCRIPTION
The captainfile didn't use `$$cap_tz` and without the `TZ` env varriable alpine stays in UTC.

With this fix, the container will now have the proper timezone set.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
