### PR TITLE
Updates Wordpress to v6 and MySQL to v8

### DIFF
--- a/public/v4/apps/wordpress.yml
+++ b/public/v4/apps/wordpress.yml
@@ -35,7 +35,7 @@ caproverOneClickApp:
           validRegex: /^(\w|[^\s"'\\])+$/
         - id: $$cap_wp_version
           label: WordPress Version
-          defaultValue: '4.9'
+          defaultValue: '6.0.1'
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/library/wordpress/tags/
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_db_type
@@ -45,7 +45,7 @@ caproverOneClickApp:
           validRegex: /^(mysql|mariadb)$/
         - id: $$cap_database_version
           label: Database Version, default is MySQL
-          defaultValue: '5.7'
+          defaultValue: '8.0.29'
           description: Check out the Docker pages for the valid tags https://hub.docker.com/r/library/mysql/tags/ or https://hub.docker.com/_/mariadb?tab=tags
           validRegex: /^([^\s^\/])+$/
     instructions:


### PR DESCRIPTION
Updates Wordpress App default versions to:
- Wordpress from v4.9 (giving outdated PHP version warning) to v6.0.1
- MySQL from v5.7 to v8.0.29


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
