### PR TITLE
update: strapi docker image

### DIFF
--- a/public/v4/apps/strapi.yml
+++ b/public/v4/apps/strapi.yml
@@ -67,6 +67,6 @@ caproverOneClickApp:
             Note when installing a plugin an error will be displayed. This error message is due to a restart on plugin installation.
             This behaviour is normal. Refresh the page after few seconds (502 can happen if you refresh too fast).
     displayName: ''
-    isOfficial: true
+    isOfficial: false
     description: The Open source Headless CMS Front-End Developers love. Manage your content. Distribute it anywhere
     documentation: Taken from https://github.com/strapi/strapi-docker/blob/master/examples/mongo/docker-compose.yml

--- a/public/v4/apps/strapi.yml
+++ b/public/v4/apps/strapi.yml
@@ -3,11 +3,12 @@ services:
     $$cap_appname:
         depends_on:
             - $$cap_appname-mongo
-        image: strapi/strapi:$$cap_strapi_version
+        image: naskio/strapi:$$cap_strapi_version
         volumes:
             - $$cap_appname-data:/srv/app
         restart: always
         environment:
+            NODE_ENV: production
             DATABASE_CLIENT: mongo
             DATABASE_HOST: srv-captain--$$cap_appname-mongo
             DATABASE_PORT: '27017'
@@ -33,7 +34,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_strapi_version
           label: Strapi Version
-          defaultValue: 3.5.4
+          defaultValue: 4.3.2
           description: Check out the Docker page for the valid tags https://hub.docker.com/r/strapi/strapi/tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_mongo_version


### PR DESCRIPTION
Update Strapi docker image since the official isn't maintained anymore.

The new image repositories are https://hub.docker.com/r/naskio/strapi

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
