### PR TITLE
fix: `My Account` view breaks for admin account after initial deployment

### DIFF
--- a/public/v4/apps/rocketchat.yml
+++ b/public/v4/apps/rocketchat.yml
@@ -13,6 +13,7 @@ services:
             MONGO_OPLOG_URL: mongodb://$$cap_mongodb_root_username:$$cap_mongodb_root_password@srv-captain--$$cap_appname-db:27017/local?replicaSet=rs0&authSource=admin
 
             ADMIN_NAME: $$cap_admin_name
+            ADMIN_EMAIL: $$cap_admin_email
             ADMIN_USERNAME: $$cap_admin_username
             ADMIN_PASS: $$cap_admin_password
 
@@ -25,7 +26,6 @@ services:
 
     $$cap_appname-db:
         image: bitnami/mongodb:$$cap_app_db_version
-        restart: on-failure
         volumes:
             - $$cap_appname-db-data:/bitnami/mongodb
         environment:
@@ -50,16 +50,21 @@ caproverOneClickApp:
     variables:
         - id: $$cap_app_version
           label: Rocket.Chat Version
-          description: See version numbers at https://hub.docker.com/r/library/rocket-chat/tags/ or https://github.com/RocketChat/Rocket.Chat/releases. Version must be >=4.x.y
-          defaultValue: '4.2.1'
-          # enforcing deployment of v4+
-          validRegex: /^[4-9](\.[0-9](\.[0-9])?)?$/
+          description: See version numbers at https://hub.docker.com/r/rocketchat/rocket.chat/tags or https://github.com/RocketChat/Rocket.Chat/releases. Version must be >=5.x.y
+          defaultValue: '5.0.4'
+          # enforcing deployment of v5.0.4+
+          validRegex: /^[5-9](\.[0-9](\.[4-9])?)?$/
 
         - id: $$cap_admin_name
           label: Rocket.Chat Admin Real Name
           defaultValue: Captain
           description: Real name of your Rocket.Chat instance's Admin user
           validRegex: /^[a-zA-Z0-9\.-\s]+$/
+
+        - id: $$cap_admin_email
+          label: Rocket.Chat Admin Email Account
+          description: Email address of Rocket.Chat instance's Admin user
+          validRegex: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
 
         - id: $$cap_admin_username
           label: Rocket.Chat Admin Username


### PR DESCRIPTION
* This also increases the default/minimum version to deploy to 5.0.4 (current latest)

Closes: https://github.com/RocketChat/Rocket.Chat/issues/26637

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
