### PR TITLE
Fix Listmonk one-click app (wiping DB every time)

### DIFF
--- a/public/v4/apps/listmonk.yml
+++ b/public/v4/apps/listmonk.yml
@@ -27,7 +27,7 @@ services:
             containerHttpPort: 9000
             dockerfileLines:
                 - FROM listmonk/listmonk:$$cap_listmonk_version
-                - CMD yes | ./listmonk --install && ./listmonk
+                - CMD yes | ./listmonk --install --idempotent && ./listmonk
         volumes:
             - $$cap_appname-data:/listmonk
         depends_on:


### PR DESCRIPTION
Currently, every time the container is restarted the DB is wiped-out! 

This is due to `idempotent = false` by default (doc: "make --install run only if the database isn't already setup"). Setting ` --idempotent` ensures that DB will be initialized only if empty (i.e. the first time).

[source 1](https://github.com/knadh/listmonk/blob/57dbb9e5dbf11b40ad97bbdfe3c39bb9119baea7/cmd/init.go#L108), [source 2](https://github.com/knadh/listmonk/blob/e99c8ed86b71bbcf8bfb2e5361147cec7137cf75/cmd/install.go#L26), [source 3](https://github.com/knadh/listmonk/blob/e99c8ed86b71bbcf8bfb2e5361147cec7137cf75/cmd/install.go#L46)

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
