### PR TITLE
Bump Elasticsearch and Kibana to v8

### DIFF
--- a/public/v4/apps/elasticsearch.yml
+++ b/public/v4/apps/elasticsearch.yml
@@ -6,47 +6,35 @@ services:
             - $$cap_appname-elasticsearch-data:/usr/share/elasticsearch/data
         restart: always
         environment:
-            ES_JAVA_OPTS: -Xms512m -Xmx512m
+            CLI_JAVA_OPTS: -Xms512m -Xmx512m
             cluster.name: $$cap_elasticsearch_cluster_name
-            cluster.initial_master_nodes: $$cap_elasticsearch_cluster_initial_master_nodes
+            discovery.type: $$cap_elasticsearch_discovery_type
             http.port: $$cap_container_port
             node.name: $$cap_appname
-            node.master: $$cap_elasticsearch_node_master
-            node.data: $$cap_elasticsearch_node_data
-            discovery.seed_hosts: $$cap_elasticsearch_discovery_seed_hosts
+            xpack.security.enabled: $$cap_elasticsearch_security_enabled
         caproverExtra:
             containerHttpPort: $$cap_container_port
 caproverOneClickApp:
     variables:
         - id: $$cap_elasticsearch_version
-          label: 'Elasticsearch Version Tag '
-          description: 'Check out the releases overview: https://www.elastic.co/de/downloads/elasticsearch'
-          defaultValue: 7.8.0
+          label: 'Elasticsearch Version Tag'
+          description: 'Check out the releases overview: https://hub.docker.com/_/elasticsearch'
+          defaultValue: 8.4.1
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_elasticsearch_cluster_name
           label: Cluster Name
           description: Only nodes within the same cluster name can be combined
           defaultValue: elasticsearch-cluster
           validRegex: /^([^\s^\/])+$/
-        - id: $$cap_elasticsearch_cluster_initial_master_nodes
-          label: Cluster Initial Master Nodes
-          description: Nodes to be used as master nodes. If this is the master node, put the 'App Name' selected above
-          defaultValue: ''
+        - id: $$cap_elasticsearch_discovery_type
+          label: Discovery Type
+          description: Discovery type, for a single node cluster use `single-node`, otherwise `multi-node`
+          defaultValue: single-node
           validRegex: /^([^\s^\/])+$/
-        - id: $$cap_elasticsearch_node_data
-          label: Node Data
-          description: Should the node used for storing data? (true / false)
-          defaultValue: 'true'
-          validRegex: /^([^\s^\/])+$/
-        - id: $$cap_elasticsearch_node_master
-          label: Node Master
-          description: Define node as master-eligible (usual first node TRUE, others FALSE).
-          defaultValue: 'true'
-          validRegex: /^([^\s^\/])+$/
-        - id: $$cap_elasticsearch_discovery_seed_hosts
-          label: Discovery seed hosts
-          defaultValue: srv-captain--XXX
-          description: Domains to start the discovery of other nodes
+        - id: $$cap_elasticsearch_security_enabled
+          label: Security Enabled
+          defaultValue: 'false'
+          description: 'When you enable this option, Elasticsearch will create a random password (see startup logs) for the `elastic` user and create SSL certificates required for authentication. It is recommended to leave this off for a quick setup. Warning: make sure to enable HTTP Basic Auth in CapRover!'
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_container_port
           label: Container TCP Port

--- a/public/v4/apps/kibana.yml
+++ b/public/v4/apps/kibana.yml
@@ -6,7 +6,7 @@ services:
             KIBANA_DEFAULTAPPID: $$cap_KIBANA_DEFAULTAPPID
             MONITORING_ENABLED: $$cap_MONITORING_ENABLED
             ELASTICSEARCH_HOSTS: $$cap_ELASTICSEARCH_HOSTS
-            server.publicBaseUrl: http://$$cap_appname.$$cap_root_domain/
+            SERVER_PUBLICBASEURL: $$cap_SERVER_PUBLICBASEURL
         image: docker.elastic.co/kibana/kibana:$$cap_version
         restart: always
         caproverExtra:
@@ -28,6 +28,10 @@ caproverOneClickApp:
         - label: ELASTICSEARCH_HOSTS
           description: URL of the elasticsearch hosts to use. Please include the http or https in the urls. eg. http://srv-captain--elastic:9200
           id: $$cap_ELASTICSEARCH_HOSTS
+        - label: SERVER_PUBLICBASEURL
+          defaultValue: http://$$cap_appname.$$cap_root_domain
+          description: The public URL of the Kibana app. Make sure to change this if you force HTTPS-only!
+          id: $$cap_SERVER_PUBLICBASEURL
     instructions:
         end: >-
             That's it! If you get a 502 it might mean that kibana cannot find your elasticsearch instance. Please recheck your configs.

--- a/public/v4/apps/kibana.yml
+++ b/public/v4/apps/kibana.yml
@@ -6,6 +6,7 @@ services:
             KIBANA_DEFAULTAPPID: $$cap_KIBANA_DEFAULTAPPID
             MONITORING_ENABLED: $$cap_MONITORING_ENABLED
             ELASTICSEARCH_HOSTS: $$cap_ELASTICSEARCH_HOSTS
+            server.publicBaseUrl: http://$$cap_appname.$$cap_root_domain/
         image: docker.elastic.co/kibana/kibana:$$cap_version
         restart: always
         caproverExtra:
@@ -13,8 +14,8 @@ services:
 caproverOneClickApp:
     variables:
         - label: Kibana version
-          defaultValue: 7.8.0
-          description: It's highly recommended that you don't use the latest tag but instead the major version you need.
+          defaultValue: 8.4.1
+          description: It's highly recommended that you don't use the latest tag but instead the major version you need. See https://hub.docker.com/_/kibana for a list of versions.
           id: $$cap_version
         - label: Default App id
           defaultValue: home
@@ -25,7 +26,7 @@ caproverOneClickApp:
           defaultValue: 'true'
           id: $$cap_MONITORING_ENABLED
         - label: ELASTICSEARCH_HOSTS
-          description: URL of the elasticsearch hosts to use. Please include the http or https in the urls. eg. http://srv-captain--elastic
+          description: URL of the elasticsearch hosts to use. Please include the http or https in the urls. eg. http://srv-captain--elastic:9200
           id: $$cap_ELASTICSEARCH_HOSTS
     instructions:
         end: >-


### PR DESCRIPTION
This PR bumps the one-click-apps of Elasticsearch and Kibana to v8.

Since ES v8 authentication is done in a completely different way than ES7, I decided to disable the security features by default and remind the user to enable HTTP Basic Auth. The alternative is much harder for a new setup:
* Download the auto-generated SSL certificate from the running container
* Scan the logs to the auto-generated password, or execute a command to change it after bootstrap
* Connect to the instance using the downloaded self-signed certificate and the password

I personally think that disabled auth + basic auth is the best way to set up a quick ES8 cluster. See also e.g.: https://github.com/cars10/elasticvue/wiki/Elasticsearch-8