### PR TITLE
improved photoprism one-click template

### DIFF
--- a/public/v4/apps/photoprism.yml
+++ b/public/v4/apps/photoprism.yml
@@ -48,6 +48,7 @@ services:
     $$cap_appname-ofelia:
         restart: unless-stopped
         image: "mcuadros/ofelia:$$ofelia_version"
+        command: daemon --docker
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock:ro"
         caproverExtra:

--- a/public/v4/apps/photoprism.yml
+++ b/public/v4/apps/photoprism.yml
@@ -1,58 +1,52 @@
 captainVersion: 4
 services:
     $$cap_appname:
-        image: "photoprism/photoprism:$$app_version"
+        image: 'photoprism/photoprism:$$app_version'
         depends_on:
             - $$cap_appname-db
         environment:
             PHOTOPRISM_ADMIN_PASSWORD: $$app_admin_password
             PHOTOPRISM_AUTH_MODE: password
-            PHOTOPRISM_SITE_URL: "https://$$cap_appname.$$cap_root_domain"
+            PHOTOPRISM_SITE_URL: 'https://$$cap_appname.$$cap_root_domain'
             PHOTOPRISM_ORIGINALS_LIMIT: $$app_upload_size_limit
             PHOTOPRISM_HTTP_COMPRESSION: gzip
-            PHOTOPRISM_UPLOAD_NSFW: "true"
+            PHOTOPRISM_UPLOAD_NSFW: 'true'
             PHOTOPRISM_DATABASE_DRIVER: mysql
             PHOTOPRISM_DATABASE_SERVER: srv-captain--$$cap_appname-db
             PHOTOPRISM_DATABASE_NAME: photoprism
             PHOTOPRISM_DATABASE_USER: photoprism
             PHOTOPRISM_DATABASE_PASSWORD: $$db_password
         volumes:
-            - "$$cap_appname-originals:/photoprism/originals"
-            - "$$cap_appname-storage:/photoprism/storage"
+            - '$$cap_appname-originals:/photoprism/originals'
+            - '$$cap_appname-storage:/photoprism/storage'
         working_dir: /photoprism
         labels:
-            $$cap_appname-ofelia.enabled: $$ofelia_enabled
-            $$cap_appname-ofelia.job-exec.photoprism_index.schedule: "$$ofelia_index_schedule"
-            $$cap_appname-ofelia.job-exec.photoprism_index.command: "photoprism index --cleanup"
+            $$cap_appname-chadburn.enabled: $$chadburn_enabled
+            $$cap_appname-chadburn.job-exec.photoprism_index.schedule: '$$chadburn_index_schedule'
+            $$cap_appname-chadburn.job-exec.photoprism_index.command: 'photoprism index --cleanup'
         caproverExtra:
-            containerHttpPort: "2342"
+            containerHttpPort: '2342'
     $$cap_appname-db:
         restart: unless-stopped
-        image: "mariadb:$$db_version"
-        command: >-
-            mysqld --innodb-buffer-pool-size=512M
-            --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4
-            --collation-server=utf8mb4_unicode_ci --max-connections=512
-            --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120
+        image: 'mariadb:$$db_version'
         volumes:
-            - "$$cap_appname-db:/var/lib/mysql"
+            - '$$cap_appname-db:/var/lib/mysql'
         environment:
-            MARIADB_AUTO_UPGRADE: "1"
-            MARIADB_INTDB_SKIP_TZINFO: "1"
+            MARIADB_AUTO_UPGRADE: '1'
+            MARIADB_INTDB_SKIP_TZINFO: '1'
             MARIADB_DATABASE: photoprism
             MARIADB_USER: photoprism
             MARIADB_PASSWORD: $$db_password
             MARIADB_ROOT_PASSWORD: $$db_root_password
         caproverExtra:
-            notExposeAsWebApp: "true"
-    $$cap_appname-ofelia:
+            notExposeAsWebApp: 'true'
+    $$cap_appname-chadburn:
         restart: unless-stopped
-        image: "mcuadros/ofelia:$$ofelia_version"
-        command: daemon --docker
+        image: 'ghcr.io/premoweb/chadburn:$$chadburn_version'
         volumes:
-            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+            - '/var/run/docker.sock:/var/run/docker.sock:ro'
         caproverExtra:
-            notExposeAsWebApp: "true"
+            notExposeAsWebApp: 'true'
 caproverOneClickApp:
     variables:
         - id: $$app_version
@@ -66,15 +60,15 @@ caproverOneClickApp:
           label: Photoprism Admin Password
           defaultValue: $$cap_gen_random_hex(32)
           description: Set a secure password for the admin user
-          validRegex: "/.{1,}/"
+          validRegex: '/.{1,}/'
         - id: $$app_upload_size_limit
           label: File Size Limit
-          defaultValue: "5000"
+          defaultValue: '5000'
           description: File Size Limit for Originals in MB
           validRegex: '/^([^\s^\/])+$/'
         - id: $$db_version
           label: Mariadb Version
-          defaultValue: "10.9"
+          defaultValue: '10.9'
           description: >-
               Check out their Docker page for the valid tags
               https://hub.docker.com/_/mariadb/tags
@@ -83,28 +77,28 @@ caproverOneClickApp:
           label: MariaDB User Password
           defaultValue: $$cap_gen_random_hex(32)
           description: User password for the database
-          validRegex: "/.{1,}/"
+          validRegex: '/.{1,}/'
         - id: $$db_root_password
           label: MariaDB Root Password
           defaultValue: $$cap_gen_random_hex(32)
           description: Root password for the database
-          validRegex: "/.{1,}/"
-        - id: $$ofelia_version
-          label: Ofelia Version
-          defaultValue: v0.3.6
+          validRegex: '/.{1,}/'
+        - id: $$chadburn_version
+          label: Chadburn Version
+          defaultValue: 1.0.3
           description: >-
               Check out their Docker page for the valid tags
-              https://hub.docker.com/r/mcuadros/ofelia
-        - id: $$ofelia_enabled
+              https://hub.docker.com/r/premoweb/chadburn/tags
+        - id: $$chadburn_enabled
           label: Enable scheduling for indexing files
           defaultValue: false
           description: >-
               Enable scheduling for indexing files from the originals folder. Useful is the originals folder is shared by another app, like nextcloud, etc. For scheduling imports, etc, simply use the photoprism GUI.
-        - id: $$ofelia_index_schedule
+        - id: $$chadburn_index_schedule
           label: Enable scheduling for indexing files in the originals folder
-          defaultValue: "@every 1h"
+          defaultValue: '@every 1h'
           description: >-
-              Set the time frame for scheduling indexing files from the originals folder. Check out the allowed values here: https://hub.docker.com/r/mcuadros/ofelia
+              Set the time frame for scheduling indexing files from the originals folder. Check out the allowed values here: https://github.com/PremoWeb/chadburn
     instructions:
         start: |-
             AI-Powered Photos App for the Decentralized Web
@@ -116,4 +110,4 @@ caproverOneClickApp:
     displayName: Photoprism (vbbot)
     isOfficial: true
     description: AI-Powered Photos App for the Decentralized Web
-    documentation: "See https://photoprism.app/"
+    documentation: 'See https://photoprism.app/'

--- a/public/v4/apps/photoprism.yml
+++ b/public/v4/apps/photoprism.yml
@@ -42,7 +42,7 @@ services:
             notExposeAsWebApp: 'true'
     $$cap_appname-chadburn:
         restart: unless-stopped
-        image: 'ghcr.io/premoweb/chadburn:$$chadburn_version'
+        image: 'premoweb/chadburn:$$chadburn_version'
         volumes:
             - '/var/run/docker.sock:/var/run/docker.sock:ro'
         caproverExtra:

--- a/public/v4/apps/photoprism.yml
+++ b/public/v4/apps/photoprism.yml
@@ -1,23 +1,118 @@
 captainVersion: 4
 services:
     $$cap_appname:
-        image: photoprism/photoprism:$$cap_photoprism_version
+        image: "photoprism/photoprism:$$app_version"
+        depends_on:
+            - $$cap_appname-db
+        environment:
+            PHOTOPRISM_ADMIN_PASSWORD: $$app_admin_password
+            PHOTOPRISM_AUTH_MODE: password
+            PHOTOPRISM_SITE_URL: "https://$$cap_appname.$$cap_root_domain"
+            PHOTOPRISM_ORIGINALS_LIMIT: $$app_upload_size_limit
+            PHOTOPRISM_HTTP_COMPRESSION: gzip
+            PHOTOPRISM_UPLOAD_NSFW: "true"
+            PHOTOPRISM_DATABASE_DRIVER: mysql
+            PHOTOPRISM_DATABASE_SERVER: srv-captain--$$cap_appname-db
+            PHOTOPRISM_DATABASE_NAME: photoprism
+            PHOTOPRISM_DATABASE_USER: photoprism
+            PHOTOPRISM_DATABASE_PASSWORD: $$db_password
         volumes:
-            - $$cap_appname-data:/photoprism/originals/
-        restart: always
+            - "$$cap_appname-originals:/photoprism/originals"
+            - "$$cap_appname-storage:/photoprism/storage"
+        working_dir: /photoprism
+        labels:
+            $$cap_appname-ofelia.enabled: $$ofelia_enabled
+            $$cap_appname-ofelia.job-exec.photoprism_index.schedule: "$$ofelia_index_schedule"
+            $$cap_appname-ofelia.job-exec.photoprism_index.command: "photoprism index --cleanup"
         caproverExtra:
-            containerHttpPort: '2342'
+            containerHttpPort: "2342"
+    $$cap_appname-db:
+        restart: unless-stopped
+        image: "mariadb:$$db_version"
+        command: >-
+            mysqld --innodb-buffer-pool-size=512M
+            --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4
+            --collation-server=utf8mb4_unicode_ci --max-connections=512
+            --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120
+        volumes:
+            - "$$cap_appname-db:/var/lib/mysql"
+        environment:
+            MARIADB_AUTO_UPGRADE: "1"
+            MARIADB_INTDB_SKIP_TZINFO: "1"
+            MARIADB_DATABASE: photoprism
+            MARIADB_USER: photoprism
+            MARIADB_PASSWORD: $$db_password
+            MARIADB_ROOT_PASSWORD: $$db_root_password
+        caproverExtra:
+            notExposeAsWebApp: "true"
+    $$cap_appname-ofelia:
+        restart: unless-stopped
+        image: "mcuadros/ofelia:$$ofelia_version"
+        volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+        caproverExtra:
+            notExposeAsWebApp: "true"
 caproverOneClickApp:
     variables:
-        - id: $$cap_photoprism_version
+        - id: $$app_version
           label: Photoprism Version
-          defaultValue: '20200427'
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/photoprism/photoprism/tags
-          validRegex: /^([^\s^\/])+$/
+          defaultValue: 220901-bullseye
+          description: >-
+              Check out their Docker page for the valid tags
+              https://hub.docker.com/r/photoprism/photoprism/tags
+          validRegex: '/^([^\s^\/])+$/'
+        - id: $$app_admin_password
+          label: Photoprism Admin Password
+          defaultValue: $$cap_gen_random_hex(32)
+          description: Set a secure password for the admin user
+          validRegex: "/.{1,}/"
+        - id: $$app_upload_size_limit
+          label: File Size Limit
+          defaultValue: "5000"
+          description: File Size Limit for Originals in MB
+          validRegex: '/^([^\s^\/])+$/'
+        - id: $$db_version
+          label: Mariadb Version
+          defaultValue: "10.9"
+          description: >-
+              Check out their Docker page for the valid tags
+              https://hub.docker.com/_/mariadb/tags
+          validRegex: '/^([^\s^\/])+$/'
+        - id: $$db_password
+          label: MariaDB User Password
+          defaultValue: $$cap_gen_random_hex(32)
+          description: User password for the database
+          validRegex: "/.{1,}/"
+        - id: $$db_root_password
+          label: MariaDB Root Password
+          defaultValue: $$cap_gen_random_hex(32)
+          description: Root password for the database
+          validRegex: "/.{1,}/"
+        - id: $$ofelia_version
+          label: Ofelia Version
+          defaultValue: v0.3.6
+          description: >-
+              Check out their Docker page for the valid tags
+              https://hub.docker.com/r/mcuadros/ofelia
+        - id: $$ofelia_enabled
+          label: Enable scheduling for indexing files
+          defaultValue: false
+          description: >-
+              Enable scheduling for indexing files from the originals folder. Useful is the originals folder is shared by another app, like nextcloud, etc. For scheduling imports, etc, simply use the photoprism GUI.
+        - id: $$ofelia_index_schedule
+          label: Enable scheduling for indexing files in the originals folder
+          defaultValue: "@every 1h"
+          description: >-
+              Set the time frame for scheduling indexing files from the originals folder. Check out the allowed values here: https://hub.docker.com/r/mcuadros/ofelia
     instructions:
-        start: PhotoPrism is a server-based application for browsing, organizing and sharing your personal photo collection. We recommend hosting PhotoPrism on a server with at least 2 cores and 4 GB of memory. It makes use of the latest technologies to automatically tag and find pictures without getting in your way.
-        end: PhotoPrism is deployed and available as $$cap_appname. Please also enable Websockets in the Caprover UI. When you log in the default password is 'photoprism'
-    displayName: PhotoPrism
+        start: |-
+            AI-Powered Photos App for the Decentralized Web
+            More details: https://photoprism.app/
+        end: >-
+            Photoprism  has been successfully deployed! Important further steps:
+            1. Enable HTTPS on the domain.
+            2. Enable websocket support
+    displayName: Photoprism (vbbot)
     isOfficial: true
-    description: An app for browsing, organizing and sharing your personal photo collection.
-    documentation: Taken from https://hub.docker.com/r/photoprism/photoprism
+    description: AI-Powered Photos App for the Decentralized Web
+    documentation: "See https://photoprism.app/"


### PR DESCRIPTION
_The previous pull request got closed because I changed the branch name for better organisation._

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.

Made the following changes to the template:
1. Added mariadb as the default database driver
2. Added the environment variable to set the default admin password
3. Added a persistent volume for /photoprism/storage which allows settings, cache, databases, etc to persist across container restarts
4. Added an option for running a scheduler to automatically index files in the originals folder using ofelia
5. General improvements to the template instructions, etc.
6. Some other minor tweaks too minor to be included in this list (which I also conveniently can't remember)

PS: I am not prefixing "cap" at the start of the variables because I feel the user defined variables get confused with the system-defined variables such as $$cap_appname or $$cap_root_domain, etc