### PR TITLE
fix: typo in appwrite

### DIFF
--- a/public/v4/apps/appwrite.yml
+++ b/public/v4/apps/appwrite.yml
@@ -574,7 +574,7 @@ caproverOneClickApp:
         end: |-
             Appwrite has been successfully deployed!
             Please change the following settings before using the service:
-            1. Go the settings for $$cap_appname
+            1. Go to the settings for $$cap_appname
             2. Enable "Websocket Support"
             3. Click on "Edit Default Nginx Configurations" and paste the following content before the last closing bracket "}":
                 ```


### PR DESCRIPTION
Sorry, I had a typo in my Appwrite pull request:
  - https://github.com/caprover/one-click-apps/pull/731

This pull request fixes it.

## Checks

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
