### PR TITLE
fix(rocketchat): replace hardcoded username in end instructions

### DIFF
--- a/public/v4/apps/rocketchat.yml
+++ b/public/v4/apps/rocketchat.yml
@@ -119,7 +119,7 @@ caproverOneClickApp:
             For more information see https://github.com/RocketChat/Rocket.Chat
         end: |-
             Your Rocket.Chat instance is now available at http://$$cap_appname.$$cap_root_domain
-            Log in to your newly deployed Rocket.Chat instance with the default admin account, username: "captain" and password: "$$cap_admin_password"
+            Log in to your newly deployed Rocket.Chat instance with the default admin account, username: "$$cap_admin_username" and password: "$$cap_admin_password"
             If you face any issues, you can reach out at,
             Forum: https://forums.rocket.chat
             Open Community Server: https://open.rocket.chat/channel/support


### PR DESCRIPTION
Fixed hardcoded "captain" user name in the end instructions for Rocket.Chat. 

## Checks

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
