### PR TITLE
feat(poste-io): instructions and customization

### DIFF
--- a/public/v4/apps/poste-io.yml
+++ b/public/v4/apps/poste-io.yml
@@ -1,52 +1,143 @@
 captainVersion: 4
 services:
     $$cap_appname:
-        image: analogic/poste.io:$$cap_poste_version
-        ports:
-            - 25:25
-            - 110:110
-            - 143:143
-            - 465:465
-            - 587:587
-            - 993:993
-            - 995:995
-            - 4190:4190
-        volumes:
-            - /etc/localtime:/etc/localtime:ro
-            - $$cap_appname-data:/data
-        restart: always
+        image: analogic/poste.io:$$cap_POSTE_VERSION
+        hostname: $$cap_POSTE_HOSTNAME
         environment:
-            HTTPS: OFF
-            LETSENCRYPT_EMAIL: $$cap_email
-            LETSENCRYPT_HOST: $$cap_host
-            VIRTUAL_HOST: $$cap_host
+            TZ: $$cap_POSTE_TZ
+            HTTPS: $$cap_POSTE_HTTPS
+            DISABLE_CLAMAV: $$cap_POSTE_DISABLE_CLAMAV
+            DISABLE_RSPAMD: $$cap_POSTE_DISABLE_RSPAMD
+            DISABLE_ROUNDCUBE: $$cap_POSTE_DISABLE_ROUNDCUBE
+            VIRTUAL_HOST: $$cap_POSTE_HOSTNAME
+        ports:
+            - $$cap_POSTE_PORT_SMTP_UNENCRYPTED:$$cap_POSTE_PORT_SMTP_UNENCRYPTED
+            - $$cap_POSTE_PORT_POP3_UNENCRYPTED:$$cap_POSTE_PORT_POP3_UNENCRYPTED
+            - $$cap_POSTE_PORT_IMAP_UNENCRYPTED:$$cap_POSTE_PORT_IMAP_UNENCRYPTED
+            - $$cap_POSTE_PORT_SMTP_SSL:$$cap_POSTE_PORT_SMTP_SSL
+            - $$cap_POSTE_PORT_SMTP_TLS:$$cap_POSTE_PORT_SMTP_TLS
+            - $$cap_POSTE_PORT_IMAP_TLS:$$cap_POSTE_PORT_IMAP_TLS
+            - $$cap_POSTE_PORT_POP3_ENCRYPTED:$$cap_POSTE_PORT_POP3_ENCRYPTED
+            - $$cap_POSTE_PORT_SIEVE:$$cap_POSTE_PORT_SIEVE
+        volumes:
+            - $$cap_appname:/data
 caproverOneClickApp:
-    variables:
-        - id: $$cap_poste_version
-          label: Poste.io version tag
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/analogic/poste.io/tags
-          defaultValue: '2'
-        - id: $$cap_email
-          label: Email Address
-          description: The email address used for Lets Encrypt certificates.
-        - id: $$cap_host
-          label: Hostname
-          description: The full hostname for this captain app. (usually mail.mydomain.com)
-    instructions:
-        start: >-
-            SMTP + IMAP + POP3 + Antispam + Antivirus + Web administration + Web email on your server in ~5 minutes
-
-
-            Recommended: Use "mail" as the App Name.
-        end: >-
-            Please paste the preDeployFunction from https://github.com/caprover/caprover/issues/479#issuecomment-520902309 to the App Config > Pre-Deploy section of your created poste.io instance $$cap_appname.
-
-
-            Also ensure that you've set up the reverse DNS (PTR record) for your server and DKIM, SPF (DNS TXT) records.
-
-
-            The deployment can take up to 2 minutes.
     displayName: Poste.io
     isOfficial: true
-    description: Poste.io - complete mailserver built in one container
-    documentation: Read the poste.io documentation @ https://poste.io/doc
+    description: Complete mail server built in one container
+    documentation: https://poste.io/doc
+    instructions:
+        start: |-
+            SMTP + IMAP + POP3 + Antispam + Antivirus + Web Administration + Web Mail on your server in ca. 5 minutes.
+
+            **Important notes:**
+            - You may need to open the ports `25`, `110`, `143`, `465`, `587`, `993`, `995` and `4190` on your firewall
+            - You will need access to DNS configuration after deployment
+            - It's recommended to use `mail` as the app name
+        end: |-
+            Poste.io has been successfully deployed! 
+
+            Before you can start using it, you need to perform some steps.
+            You only need to do this once.
+            **Please screenshot/copy the following instructions before proceeding:**
+
+            1. Go to the **App Configs** of your deployment `$$cap_appname` here in CapRover
+            2. Insert the following snippet into **Pre-Deploy Script**: `var preDeployFunction = function (captainAppObj, dockerUpdateObject) {var ports = dockerUpdateObject.EndpointSpec.Ports || [];ports.forEach(function (port) {port.PublishMode = "host";});return Promise.resolve(dockerUpdateObject);};`
+            3. Go to the **HTTP Settings** and **Edit Default Nginx Configurations**
+            4. Search for **last occurrence** of `location /.well-known/acme-challenge/` and replace `root <%-s.staticWebRoot%>;` with `proxy_pass $upstream;`
+            5. **Save settings** and wait a minute
+            6. Access your mail server at `https://$$cap_appname.$$cap_root_domain`
+            7. Enter `$$cap_POSTE_HOSTNAME` in **Mailserver hostname**
+            8. Enter an email address for the admin (you can also use `admin@$$cap_POSTE_HOSTNAME`) and create a password
+            9. Navigate to **System Settings** > **TLS Certificate** and **Issue Free Letsencrypt.org Certificate**
+            10. Check **Enabled** and **Save Changes**
+
+            The following steps is a guidance about configuring DNS. Please **consult the documentation** (`https://poste.io/doc/configuring-dns`).
+
+            1. Enter the admin panel of the server hosting or if you are self-hosting locally make sure you have access to the DNS configuration
+            2. Create **PTR record** (also known as **Reverse DNS**) pointing to `$$cap_POSTE_HOSTNAME`
+            3. Create **A** record for `$$cap_POSTE_HOSTNAME` pointing to the IP address of the server
+            4. Create **MX** record pointing to `$$cap_POSTE_HOSTNAME`
+            5. Create **TXT** record with value `v=spf1 mx ~all`
+            6. Create **TXT** record with value `v=DMARC1; p=none; rua=mailto:dmarc-reports@$$cap_POSTE_HOSTNAME ruf=dmarc-reports@$$cap_POSTE_HOSTNAME; sp=none; ri=86400` (you may need to change the mail addresses)
+            7. Go to your application navigating to `https://$$cap_appname.$$cap_root_domain/admin/domain`
+            8. Click **Show** on `$$cap_POSTE_HOSTNAME`
+            9. In the line **DKIM Key** click on **Create New Key** and copy the generated value
+            10. Go back to the DNS settings
+            11. Create **TXT** record and insert copied value (starting with `k=rsa...`)
+            12. Verify the DNS configuration using tools like MXToolbox (`https://mxtoolbox.com`)
+
+            If all your checks are green you are ready to create mailboxes.
+
+            Enjoy your self-hosted mail server!
+    variables:
+        - id: $$cap_POSTE_VERSION
+          label: General | Version
+          description: Check out their Docker page for the valid tags https://hub.docker.com/r/analogic/poste.io/tags
+          defaultValue: '2'
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_TZ
+          label: General | Timezone
+          description: Timezone for the application, find yours at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+          defaultValue: UTC
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_DISABLE_CLAMAV
+          label: Features | Disable ClamAV
+          description: Whether to disable ClamAV anti-virus. Useful for low memory usage. Set value `TRUE` to disable.
+        - id: $$cap_POSTE_DISABLE_RSPAMD
+          label: Features | Disable Rspamd
+          description: Whether to disable Rspamd spam filter. Useful for low memory usage. Set value `TRUE` to disable.
+        - id: $$cap_POSTE_DISABLE_ROUNDCUBE
+          label: Features | Disable Roundcube
+          description: Whether to disable Roundcube webmail. Set value `TRUE` to disable.
+        - id: $$cap_POSTE_HOSTNAME
+          label: Networking | Hostname
+          description: Hostname of your mail server. **This is required**. It is usually `mail.mydomain.com`.
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_HTTPS
+          label: Networking | Use HTTPS
+          description: >-
+              Whether to redirect to encrypted HTTP.
+              It's recommended to leave it to `OFF` since CapRover acts as reverse proxy and handles HTTPS.
+              If you want to enable it, remove the value and leave it blank and then to change the configuration and ports accordingly.
+          defaultValue: 'OFF'
+        - id: $$cap_POSTE_PORT_SMTP_UNENCRYPTED
+          label: Networking | Unencrypted SMTP Port
+          description: Port for unencrypted mail submission. Should not be changed.
+          defaultValue: 25
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_PORT_POP3_UNENCRYPTED
+          label: Networking | Unencrypted POP3 Port
+          description: Port for unencrypted mail access via POP3. Should not be changed.
+          defaultValue: 110
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_PORT_IMAP_UNENCRYPTED
+          label: Networking | Unencrypted IMAP Port
+          description: Port for unencrypted mail access via IMAP. Should not be changed.
+          defaultValue: 143
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_PORT_SMTP_SSL
+          label: Networking | SMTP With SSL Encryption Port
+          description: Port for mail submission using SSL encryption. Should not be changed.
+          defaultValue: 465
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_PORT_SMTP_TLS
+          label: Networking | SMTP With TLS/STARTTLS Encryption Port
+          description: Port for mail submission using TLS/STARTTLS encryption. Should not be changed.
+          defaultValue: 587
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_PORT_IMAP_TLS
+          label: Networking | IMAP With SSL/TLS Encryption Port
+          description: Port for SSL/TLS encrypted mail access via IMAP. Should not be changed.
+          defaultValue: 993
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_PORT_POP3_ENCRYPTED
+          label: Networking | POP3 With SSL/TLS Encryption Port
+          description: Port for SSL/TLS encrypted mail access via POP3. Should not be changed.
+          defaultValue: 995
+          validRegex: /.{1,}/
+        - id: $$cap_POSTE_PORT_SIEVE
+          label: Networking | Sieve Port
+          description: Port for remote Sieve settings. Should not be changed.
+          defaultValue: 4190
+          validRegex: /.{1,}/

--- a/public/v4/apps/poste-io.yml
+++ b/public/v4/apps/poste-io.yml
@@ -52,7 +52,7 @@ caproverOneClickApp:
             9. Navigate to **System Settings** > **TLS Certificate** and **Issue Free Letsencrypt.org Certificate**
             10. Check **Enabled** and **Save Changes**
 
-            The following steps is a guidance about configuring DNS. Please **consult the documentation** (`https://poste.io/doc/configuring-dns`).
+            The following steps guide you though the DNS configuration. Please **consult the documentation** (`https://poste.io/doc/configuring-dns`).
 
             1. Enter the admin panel of the server hosting or if you are self-hosting locally make sure you have access to the DNS configuration
             2. Create **PTR record** (also known as **Reverse DNS**) pointing to `$$cap_POSTE_HOSTNAME`

--- a/public/v4/apps/poste-io.yml
+++ b/public/v4/apps/poste-io.yml
@@ -11,14 +11,14 @@ services:
             DISABLE_ROUNDCUBE: $$cap_POSTE_DISABLE_ROUNDCUBE
             VIRTUAL_HOST: $$cap_POSTE_HOSTNAME
         ports:
-            - $$cap_POSTE_PORT_SMTP_UNENCRYPTED:$$cap_POSTE_PORT_SMTP_UNENCRYPTED
-            - $$cap_POSTE_PORT_POP3_UNENCRYPTED:$$cap_POSTE_PORT_POP3_UNENCRYPTED
-            - $$cap_POSTE_PORT_IMAP_UNENCRYPTED:$$cap_POSTE_PORT_IMAP_UNENCRYPTED
-            - $$cap_POSTE_PORT_SMTP_SSL:$$cap_POSTE_PORT_SMTP_SSL
-            - $$cap_POSTE_PORT_SMTP_TLS:$$cap_POSTE_PORT_SMTP_TLS
-            - $$cap_POSTE_PORT_IMAP_TLS:$$cap_POSTE_PORT_IMAP_TLS
-            - $$cap_POSTE_PORT_POP3_ENCRYPTED:$$cap_POSTE_PORT_POP3_ENCRYPTED
-            - $$cap_POSTE_PORT_SIEVE:$$cap_POSTE_PORT_SIEVE
+            - '25:25'
+            - '110:110'
+            - '143:143'
+            - '465:465'
+            - '587:587'
+            - '993:993'
+            - '995:995'
+            - '4190:4190'
         volumes:
             - $$cap_appname:/data
 caproverOneClickApp:
@@ -101,43 +101,3 @@ caproverOneClickApp:
               It's recommended to leave it to `OFF` since CapRover acts as reverse proxy and handles HTTPS.
               If you want to enable it, remove the value and leave it blank and then to change the configuration and ports accordingly.
           defaultValue: 'OFF'
-        - id: $$cap_POSTE_PORT_SMTP_UNENCRYPTED
-          label: Networking | Unencrypted SMTP Port
-          description: Port for unencrypted mail submission. Should not be changed.
-          defaultValue: 25
-          validRegex: /.{1,}/
-        - id: $$cap_POSTE_PORT_POP3_UNENCRYPTED
-          label: Networking | Unencrypted POP3 Port
-          description: Port for unencrypted mail access via POP3. Should not be changed.
-          defaultValue: 110
-          validRegex: /.{1,}/
-        - id: $$cap_POSTE_PORT_IMAP_UNENCRYPTED
-          label: Networking | Unencrypted IMAP Port
-          description: Port for unencrypted mail access via IMAP. Should not be changed.
-          defaultValue: 143
-          validRegex: /.{1,}/
-        - id: $$cap_POSTE_PORT_SMTP_SSL
-          label: Networking | SMTP With SSL Encryption Port
-          description: Port for mail submission using SSL encryption. Should not be changed.
-          defaultValue: 465
-          validRegex: /.{1,}/
-        - id: $$cap_POSTE_PORT_SMTP_TLS
-          label: Networking | SMTP With TLS/STARTTLS Encryption Port
-          description: Port for mail submission using TLS/STARTTLS encryption. Should not be changed.
-          defaultValue: 587
-          validRegex: /.{1,}/
-        - id: $$cap_POSTE_PORT_IMAP_TLS
-          label: Networking | IMAP With SSL/TLS Encryption Port
-          description: Port for SSL/TLS encrypted mail access via IMAP. Should not be changed.
-          defaultValue: 993
-          validRegex: /.{1,}/
-        - id: $$cap_POSTE_PORT_POP3_ENCRYPTED
-          label: Networking | POP3 With SSL/TLS Encryption Port
-          description: Port for SSL/TLS encrypted mail access via POP3. Should not be changed.
-          defaultValue: 995
-          validRegex: /.{1,}/
-        - id: $$cap_POSTE_PORT_SIEVE
-          label: Networking | Sieve Port
-          description: Port for remote Sieve settings. Should not be changed.
-          defaultValue: 4190
-          validRegex: /.{1,}/

--- a/public/v4/apps/poste-io.yml
+++ b/public/v4/apps/poste-io.yml
@@ -46,7 +46,7 @@ caproverOneClickApp:
             3. Go to the **HTTP Settings** and **Edit Default Nginx Configurations**
             4. Search for **last occurrence** of `location /.well-known/acme-challenge/` and replace `root <%-s.staticWebRoot%>;` with `proxy_pass $upstream;`
             5. **Save settings** and wait a minute
-            6. Access your mail server at `https://$$cap_appname.$$cap_root_domain`
+            6. Access your mail server at `http://$$cap_appname.$$cap_root_domain`
             7. Enter `$$cap_POSTE_HOSTNAME` in **Mailserver hostname**
             8. Enter an email address for the admin (you can also use `admin@$$cap_POSTE_HOSTNAME`) and create a password
             9. Navigate to **System Settings** > **TLS Certificate** and **Issue Free Letsencrypt.org Certificate**
@@ -60,7 +60,7 @@ caproverOneClickApp:
             4. Create **MX** record pointing to `$$cap_POSTE_HOSTNAME`
             5. Create **TXT** record with value `v=spf1 mx ~all`
             6. Create **TXT** record with value `v=DMARC1; p=none; rua=mailto:dmarc-reports@$$cap_POSTE_HOSTNAME ruf=dmarc-reports@$$cap_POSTE_HOSTNAME; sp=none; ri=86400` (you may need to change the mail addresses)
-            7. Go to your application navigating to `https://$$cap_appname.$$cap_root_domain/admin/domain`
+            7. Go to your application navigating to `http://$$cap_appname.$$cap_root_domain/admin/domain`
             8. Click **Show** on `$$cap_POSTE_HOSTNAME`
             9. In the line **DKIM Key** click on **Create New Key** and copy the generated value
             10. Go back to the DNS settings


### PR DESCRIPTION
This pull request updates the one-click-app for [Poste.io](https://poste.io/).

## Changes

- Fixed TLS certificate issues
- Added instructions
  - Added pre-deploy script
  - Explained how to set up HTTPS correctly
  - Added guidance notes on how to set up DNS entries
- Added more variables for customization (e.g. disabling ClamAV, Webmail and Rspamd)

## Checks

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.

## References

- closes #220 