### PR TITLE
fix(appwrite): prevent naming conflicts

### DIFF
--- a/public/v4/apps/appwrite.yml
+++ b/public/v4/apps/appwrite.yml
@@ -67,7 +67,7 @@ services:
             _APP_OPTIONS_ABUSE: $$cap_APP_OPTIONS_ABUSE
             _APP_OPTIONS_FORCE_HTTPS: $$cap_APP_OPTIONS_FORCE_HTTPS
             _APP_OPENSSL_KEY_V1: $$cap_APP_OPENSSL_KEY_V1
-            _APP_DOMAIN: $$cap_APP_DOMAIN
+            _APP_DOMAIN: $$cap_APP_DOMAIN_NAME
             _APP_DOMAIN_TARGET: $$cap_APP_DOMAIN_TARGET
             _APP_REDIS_HOST: srv-captain--$$cap_appname-redis
             _APP_REDIS_PORT: $$cap_APP_REDIS_PORT
@@ -88,7 +88,7 @@ services:
             _APP_INFLUXDB_PORT: $$cap_APP_INFLUXDB_PORT
             _APP_STORAGE_LIMIT: $$cap_APP_STORAGE_LIMIT
             _APP_STORAGE_PREVIEW_LIMIT: $$cap_APP_STORAGE_PREVIEW_LIMIT
-            _APP_STORAGE_ANTIVIRUS: $$cap_APP_STORAGE_ANTIVIRUS
+            _APP_STORAGE_ANTIVIRUS: $$cap_APP_STORAGE_ANTIVIRUS_ENABLED
             _APP_STORAGE_ANTIVIRUS_HOST: $$cap_APP_STORAGE_ANTIVIRUS_HOST
             _APP_STORAGE_ANTIVIRUS_PORT: $$cap_APP_STORAGE_ANTIVIRUS_PORT
             _APP_STORAGE_DEVICE: $$cap_APP_STORAGE_DEVICE
@@ -117,7 +117,7 @@ services:
             _APP_FUNCTIONS_BUILD_TIMEOUT: $$cap_APP_FUNCTIONS_BUILD_TIMEOUT
             _APP_FUNCTIONS_CONTAINERS: $$cap_APP_FUNCTIONS_CONTAINERS
             _APP_FUNCTIONS_CPUS: $$cap_APP_FUNCTIONS_CPUS
-            _APP_FUNCTIONS_MEMORY: $$cap_APP_FUNCTIONS_MEMORY
+            _APP_FUNCTIONS_MEMORY: $$cap_APP_FUNCTIONS_MEMORY_ALLOCATED
             _APP_FUNCTIONS_MEMORY_SWAP: $$cap_APP_FUNCTIONS_MEMORY_SWAP
             _APP_FUNCTIONS_RUNTIMES: $$cap_APP_FUNCTIONS_RUNTIMES
             _APP_EXECUTOR_SECRET: $$cap_APP_EXECUTOR_SECRET
@@ -182,7 +182,7 @@ services:
             _APP_FUNCTIONS_CONTAINERS: $$cap_APP_FUNCTIONS_CONTAINERS
             _APP_FUNCTIONS_RUNTIMES: $$cap_APP_FUNCTIONS_RUNTIMES
             _APP_FUNCTIONS_CPUS: $$cap_APP_FUNCTIONS_CPUS
-            _APP_FUNCTIONS_MEMORY: $$cap_APP_FUNCTIONS_MEMORY
+            _APP_FUNCTIONS_MEMORY: $$cap_APP_FUNCTIONS_MEMORY_ALLOCATED
             _APP_FUNCTIONS_MEMORY_SWAP: $$cap_APP_FUNCTIONS_MEMORY_SWAP
             _APP_FUNCTIONS_INACTIVE_THRESHOLD: $$cap_APP_FUNCTIONS_INACTIVE_THRESHOLD
             _APP_EXECUTOR_SECRET: $$cap_APP_EXECUTOR_SECRET
@@ -448,7 +448,7 @@ services:
         environment:
             _APP_ENV: $$cap_APP_ENV
             _APP_OPENSSL_KEY_V1: $$cap_APP_OPENSSL_KEY_V1
-            _APP_DOMAIN: $$cap_APP_DOMAIN
+            _APP_DOMAIN: $$cap_APP_DOMAIN_NAME
             _APP_DOMAIN_TARGET: $$cap_APP_DOMAIN_TARGET
             _APP_SYSTEM_SECURITY_EMAIL_ADDRESS: $$cap_APP_SYSTEM_SECURITY_EMAIL_ADDRESS
             _APP_REDIS_HOST: srv-captain--$$cap_appname-redis
@@ -474,7 +474,7 @@ services:
         environment:
             _APP_ENV: $$cap_APP_ENV
             _APP_OPENSSL_KEY_V1: $$cap_APP_OPENSSL_KEY_V1
-            _APP_DOMAIN: $$cap_APP_DOMAIN
+            _APP_DOMAIN: $$cap_APP_DOMAIN_NAME
             _APP_DOMAIN_TARGET: $$cap_APP_DOMAIN_TARGET
             _APP_REDIS_HOST: srv-captain--$$cap_appname-redis
             _APP_REDIS_PORT: $$cap_APP_REDIS_PORT
@@ -627,7 +627,7 @@ caproverOneClickApp:
           defaultValue: $$cap_gen_random_hex(256)
           validRegex: /^([^\s^\/])+$/
         - label: General | _APP_DOMAIN
-          id: $$cap_APP_DOMAIN
+          id: $$cap_APP_DOMAIN_NAME
           description: Your Appwrite domain address. When setting a public suffix domain, Appwrite will attempt to issue a valid SSL certificate automatically. When used with a dev domain, Appwrite will assign a self-signed SSL certificate. The default value is 'localhost'.
           defaultValue: localhost
           validRegex: /^([^\s^\/])+$/
@@ -770,7 +770,7 @@ caproverOneClickApp:
           description: Maximum file size allowed for file image preview. The default value is 20MB. You should pass your size limit value in bytes.
           defaultValue: 20000000
         - label: Storage | _APP_STORAGE_ANTIVIRUS
-          id: $$cap_APP_STORAGE_ANTIVIRUS
+          id: $$cap_APP_STORAGE_ANTIVIRUS_ENABLED
           description: This variable allows you to disable the internal anti-virus scans. This value is set to 'disabled' by default, to enable the scans set the value to 'enabled'. Before enabling, you must add the ClamAV service and depend on it on main Appwrite service.
           defaultValue: 'disabled'
         - label: Storage | _APP_STORAGE_ANTIVIRUS_HOST
@@ -876,7 +876,7 @@ caproverOneClickApp:
           id: $$cap_APP_FUNCTIONS_CPUS
           description: The maximum number of CPU core a single cloud function is allowed to use. Please note that setting a value higher than available cores will result in a function error, which might result in an error. The default value is empty. When it's empty, CPU limit will be disabled.
         - label: Functions | _APP_FUNCTIONS_MEMORY
-          id: $$cap_APP_FUNCTIONS_MEMORY
+          id: $$cap_APP_FUNCTIONS_MEMORY_ALLOCATED
           description: The maximum amount of memory a single cloud function is allowed to use in megabytes. The default value is empty. When it's empty, memory limit will be disabled.
         - label: Functions | _APP_FUNCTIONS_MEMORY_SWAP
           id: $$cap_APP_FUNCTIONS_MEMORY_SWAP


### PR DESCRIPTION
This pull request updates the one-click-application for [Appwrite](https://appwrite.io)

## Changes

- Renamed several template variables in order to prevent name conflicts
  -  Example: `_APP_DOMAIN` and `_APP_DOMAIN_TARGET`
    - `_APP_DOMAIN_TARGET` was resolved to the value of `_APP_DOMAIN` with `_TARGET` appended

## Checks

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
