### PR TITLE
chore(n8n): bump version and optimize variables

### DIFF
--- a/public/v4/apps/n8n-io.yml
+++ b/public/v4/apps/n8n-io.yml
@@ -27,6 +27,7 @@ services:
             N8N_HOST: $$cap_appname.$$cap_root_domain
             N8N_DIAGNOSTICS_ENABLED: $$cap_N8N_DIAGNOSTICS_ENABLED
             WEBHOOK_URL: https://$$cap_appname.$$cap_root_domain
+            N8N_EDITOR_BASE_URL: https://$$cap_appname.$$cap_root_domain
         volumes:
             - $$cap_appname:/root/.n8n
             - $$cap_appname-files:/files

--- a/public/v4/apps/n8n-io.yml
+++ b/public/v4/apps/n8n-io.yml
@@ -1,92 +1,87 @@
 captainVersion: 4
 services:
     $$cap_appname-db:
-        documentation: Taken from https://hub.docker.com/_/postgres
-        image: postgres:$$cap_postgres_version
-        volumes:
-            - $$cap_appname-db-data:/var/lib/postgresql/data
-        restart: always
-        environment:
-            POSTGRES_PASSWORD: $$cap_db_pass
-            POSTGRES_DB: n8n
-            POSTGRES_USER: $$cap_db_user
         caproverExtra:
             notExposeAsWebApp: 'true'
+        image: postgres:$$cap_POSTGRES_VERSION
+        environment:
+            POSTGRES_DB: $$cap_POSTGRES_DB
+            POSTGRES_USER: $$cap_POSTGRES_USER
+            POSTGRES_PASSWORD: $$cap_POSTGRES_PASSWORD
+        volumes:
+            - $$cap_appname-db:/var/lib/postgresql/data
     $$cap_appname:
-        documentation: Taken from https://hub.docker.com/r/n8nio/n8n
+        caproverExtra:
+            containerHttpPort: 5678
+        image: n8nio/n8n:$$cap_N8N_VERSION
+        environment:
+            DB_TYPE: postgresdb
+            DB_POSTGRESDB_HOST: srv-captain--$$cap_appname-db
+            DB_POSTGRESDB_DATABASE: $$cap_POSTGRES_DB
+            DB_POSTGRESDB_USER: $$cap_POSTGRES_USER
+            DB_POSTGRESDB_PASSWORD: $$cap_POSTGRES_PASSWORD
+            GENERIC_TIMEZONE: $$cap_N8N_TIMEZONE
+            TZ: $$cap_N8N_TIMEZONE
+            NODE_ENV: $$cap_N8N_ENVIRONMENT
+            N8N_PROTOCOL: https
+            N8N_HOST: $$cap_appname.$$cap_root_domain
+            N8N_DIAGNOSTICS_ENABLED: $$cap_N8N_DIAGNOSTICS_ENABLED
+            WEBHOOK_URL: https://$$cap_appname.$$cap_root_domain
+        volumes:
+            - $$cap_appname:/root/.n8n
+            - $$cap_appname-files:/files
         depends_on:
             - $$cap_appname-db
-        image: n8nio/n8n:$$cap_n8n_version
-        volumes:
-            - $$cap_appname-data:/root/.n8n
-            - $$cap_appname-data-write:/files
-            - /var/run/docker.sock:/var/run/docker.sock
-        environment:
-            DB_POSTGRESDB_DATABASE: n8n
-            DB_POSTGRESDB_HOST: srv-captain--$$cap_appname-db
-            DB_POSTGRESDB_PASSWORD: $$cap_db_pass
-            DB_POSTGRESDB_PORT: '5432'
-            DB_POSTGRESDB_USER: $$cap_db_user
-            DB_TYPE: postgresdb
-            GENERIC_TIMEZONE: $$cap_timezone
-            TZ: $$cap_timezone
-            N8N_PROTOCOL: http
-            WEBHOOK_TUNNEL_URL: https://$$cap_appname.$$cap_root_domain/
-            VUE_APP_URL_BASE_API: https://$$cap_appname.$$cap_root_domain/
-            N8N_HOST: https://$$cap_appname.$$cap_root_domain/
-            N8N_BASIC_AUTH_ACTIVE: 'true'
-            N8N_BASIC_AUTH_USER: $$cap_user
-            N8N_BASIC_AUTH_PASSWORD: $$cap_pass
-        restart: always
-        caproverExtra:
-            containerHttpPort: '5678'
 caproverOneClickApp:
-    variables:
-        - id: $$cap_n8n_version
-          label: n8n.io Version
-          defaultValue: 0.183.0
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/n8nio/n8n/tags
-          validRegex: /^([^\s^\/])+$/
-        - id: $$cap_postgres_version
-          label: Postgres (database) version
-          defaultValue: '14'
-          description: Check out their Docker page for the valid tags https://hub.docker.com/_/postgres?tab=tags
-          validRegex: /^([^\s^\/])+$/
-        - id: $$cap_db_pass
-          label: database password
-          defaultValue: $$cap_gen_random_hex(16)
-          description: Password for the database user and root using mysql.
-          validRegex: /.{1,}/
-        - id: $$cap_db_user
-          label: database user
-          defaultValue: n8n
-          description: Username for the database using postgres.
-          validRegex: /^([a-z0-9])+$/i
-        - id: $$cap_timezone
-          label: timezone
-          defaultValue: Europe/Paris
-          description: Timezone used by the server. Please check out this page https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for valid time
-          validRegex: /^([a-z_\+-0-9]+\/?[a-z_\+-0-9]*)$/i
-        - id: $$cap_user
-          label: user
-          defaultValue: root
-          description: user you need to use to login into the web interface
-          validRegex: /^([a-z0-9])+$/i
-        - id: $$cap_pass
-          label: password
-          description: password you need to use to login into the web interface
-          validRegex: /.{1,}/
-    instructions:
-        start: >-
-            n8n is a free and open node based Workflow Automation Tool.
-
-            The process will deploy a database and the App. It will take about a minute for the process to finish.
-        end: >-
-            n8n is deployed and available as $$cap_appname.
-
-            IMPORTANT!! You need to enable https and websocket support.
-
-            Also, make sure you DO NOT activate basic auth manually.
     displayName: n8n.io
+    description: Node based workflow automation tool
     isOfficial: true
-    description: n8n is a free and open node based Workflow Automation Tool.
+    instructions:
+        start: n8n is a free and open node based workflow automation tool.
+        end: |-
+            n8n has been successfully deployed! It might take few moments before it's fully started.
+            You can access it at `http://$$cap_appname.$$cap_root_domain` and set up your account.
+            **Important:** Please enable **HTTPS** and **WebSocket Support**.
+    variables:
+        - id: $$cap_N8N_VERSION
+          label: Application | n8n.io
+          description: Check out their Docker page for the valid tags https://hub.docker.com/r/n8nio/n8n/tags
+          defaultValue: '0.198.2'
+          validRegex: /.{1,}/
+        - id: $$cap_N8N_TIMEZONE
+          label: Application | Timezone
+          description: >-
+              Timezone used by the server.
+              Please check out this page for valid time zones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+          defaultValue: UTC
+          validRegex: /.{1,}/
+        - id: $$cap_N8N_ENVIRONMENT
+          label: Application | Environment
+          description: Application environment.
+          defaultValue: 'production'
+          validRegex: /^(production|development)$/
+        - id: $$cap_N8N_DIAGNOSTICS_ENABLED
+          label: Application | Enable Telemetry
+          description: Whether to send telemetry data to n8n.io.
+          defaultValue: 'false'
+          validRegex: /^(true|false)$/
+        - id: $$cap_POSTGRES_VERSION
+          label: Database | Version
+          description: Check out their Docker page for the valid tags https://hub.docker.com/_/postgres/tags
+          defaultValue: '15.0-alpine'
+          validRegex: /.{1,}/
+        - id: $$cap_POSTGRES_DB
+          label: Database | Name
+          defaultValue: n8n
+          description: Name of the PostgreSQL database.
+          validRegex: /.{1,}/
+        - id: $$cap_POSTGRES_USER
+          label: Database | User
+          defaultValue: n8n
+          description: Username for the PostgreSQL database.
+          validRegex: /.{1,}/
+        - id: $$cap_POSTGRES_PASSWORD
+          label: Database | Password
+          description: Password of the PostgreSQL database user.
+          defaultValue: $$cap_gen_random_hex(16)
+          validRegex: /.{1,}/

--- a/public/v4/apps/n8n-io.yml
+++ b/public/v4/apps/n8n-io.yml
@@ -26,6 +26,13 @@ services:
             N8N_PROTOCOL: https
             N8N_HOST: $$cap_appname.$$cap_root_domain
             N8N_DIAGNOSTICS_ENABLED: $$cap_N8N_DIAGNOSTICS_ENABLED
+            N8N_EMAIL_MODE: smtp
+            N8N_SMTP_HOST: $$cap_N8N_SMTP_HOST
+            N8N_SMTP_PORT: $$cap_N8N_SMTP_PORT
+            N8N_SMTP_USER: $$cap_N8N_SMTP_USER
+            N8N_SMTP_PASS: $$cap_N8N_SMTP_PASS
+            N8N_SMTP_SENDER: $$cap_N8N_SMTP_SENDER
+            N8N_SMTP_SSL: $$cap_N8N_SMTP_SSL
             WEBHOOK_URL: https://$$cap_appname.$$cap_root_domain
             N8N_EDITOR_BASE_URL: https://$$cap_appname.$$cap_root_domain
         volumes:
@@ -38,7 +45,9 @@ caproverOneClickApp:
     description: Node based workflow automation tool
     isOfficial: true
     instructions:
-        start: n8n is a free and open node based workflow automation tool.
+        start: |-
+            n8n is a free and open node based workflow automation tool.
+            If you want to invite members and enable password resets, you will need to enter SMTP details.
         end: |-
             n8n has been successfully deployed! It might take few moments before it's fully started.
             You can access it at `http://$$cap_appname.$$cap_root_domain` and set up your account.
@@ -65,6 +74,26 @@ caproverOneClickApp:
           label: Application | Enable Telemetry
           description: Whether to send telemetry data to n8n.io.
           defaultValue: 'false'
+          validRegex: /^(true|false)$/
+        - id: $$cap_N8N_SMTP_HOST
+          label: Application | SMTP Host
+          description: SMTP host used for sending mails.
+        - id: $$cap_N8N_SMTP_PORT
+          label: Application | SMTP Port
+          description: SMTP port used for sending mails. Usually `465`.
+        - id: $$cap_N8N_SMTP_USER
+          label: Application | SMTP User
+          description: SMTP user used for sending mails.
+        - id: $$cap_N8N_SMTP_PASS
+          label: Application | SMTP Password
+          description: SMTP user password used for sending mails.
+        - id: $$cap_N8N_SMTP_SENDER
+          label: Application | SMTP Sender
+          description: SMTP sender used for sending mails (e.g. `N8N <n8n@example.com>`).
+        - id: $$cap_N8N_SMTP_SSL
+          label: Application | SMTP SSL
+          description: Whether to use SSL for sending mails through SMTP.
+          defaultValue: 'true'
           validRegex: /^(true|false)$/
         - id: $$cap_POSTGRES_VERSION
           label: Database | Version


### PR DESCRIPTION
This pull request updates the one-click-application for [n8n](https://n8n.io).

## Changes

- Bumped versions to latest stable releases
  - n8n: `0.198.2`
  - PostgreSQL: `15`
- Removed unused Docker socket volume
- Removed environment variables for basic authentication since n8n provides a user account system
- Removed unnecessary environment variables like `VUE_APP_URL_BASE_API`, `WEBHOOK_TUNNEL_URL`
- Added environment variable to opt-out of telemetry
- Added environment variable for application environment

## Checks

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
