### PR TITLE
Postgres updates

### DIFF
--- a/public/v4/apps/postgres.yml
+++ b/public/v4/apps/postgres.yml
@@ -16,7 +16,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_postgres_version
           label: Postgres Version
-          defaultValue: '14.1'
+          defaultValue: '14.5'
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/library/postgres/tags/
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_pg_user

--- a/public/v4/apps/postgres.yml
+++ b/public/v4/apps/postgres.yml
@@ -1,9 +1,9 @@
 captainVersion: 4
 services:
-    $$cap_appname-db:
+    $$cap_appname:
         image: postgres:$$cap_postgres_version
         volumes:
-            - $$cap_appname-db-data:/var/lib/postgresql/data
+            - $$cap_appname-data:/var/lib/postgresql/data
         restart: always
         environment:
             POSTGRES_USER: $$cap_pg_user
@@ -44,7 +44,7 @@ caproverOneClickApp:
             After installation on CapRover, it will be available as srv-captain--YOUR_CONTAINER_NAME at port 5432 to other CapRover apps.
 
             Enter your Postgres Configuration parameters and click on next. It will take about a minute for the process to finish.
-        end: "Postgres is deployed and available as srv-captain--$$cap_appname-db:5432 to other apps. For example with NodeJS: 'const client = new Client({ user: '$$cap_pg_user', host: 'srv-captain--$$cap_appname', database: '$$cap_pg_db', password: '********', port: 5432})'"
+        end: "Postgres is deployed and available as srv-captain--$$cap_appname:5432 to other apps. For example with NodeJS: 'const client = new Client({ user: '$$cap_pg_user', host: 'srv-captain--$$cap_appname', database: '$$cap_pg_db', password: '********', port: 5432})'"
     displayName: PostgreSQL
     isOfficial: true
     description: The PostgreSQL object-relational database system provides reliability and data integrity

--- a/public/v4/apps/postgres.yml
+++ b/public/v4/apps/postgres.yml
@@ -21,6 +21,7 @@ caproverOneClickApp:
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_pg_user
           label: Postgres Username
+          defaultValue: postgres
           description: ''
           validRegex: /.{1,}/
         - id: $$cap_pg_pass
@@ -29,6 +30,7 @@ caproverOneClickApp:
           validRegex: /.{1,}/
         - id: $$cap_pg_db
           label: Postgres Default Database
+          defaultValue: postgres
           description: ''
           validRegex: /.{1,}/
         - id: $$cap_pg_initdb_args

--- a/public/v4/apps/postgres.yml
+++ b/public/v4/apps/postgres.yml
@@ -42,7 +42,7 @@ caproverOneClickApp:
             After installation on CapRover, it will be available as srv-captain--YOUR_CONTAINER_NAME at port 5432 to other CapRover apps.
 
             Enter your Postgres Configuration parameters and click on next. It will take about a minute for the process to finish.
-        end: "Postgres is deployed and available as srv-captain--$$cap_appname-db:5432 to other apps. For example with NodeJS: 'const client = new Client({ user: 'cap_pg_user', host: 'srv-captain--$$cap_appname', database: 'cap_pg_db', password: '********', port: 5432})'"
+        end: "Postgres is deployed and available as srv-captain--$$cap_appname-db:5432 to other apps. For example with NodeJS: 'const client = new Client({ user: '$$cap_pg_user', host: 'srv-captain--$$cap_appname', database: '$$cap_pg_db', password: '********', port: 5432})'"
     displayName: PostgreSQL
     isOfficial: true
     description: The PostgreSQL object-relational database system provides reliability and data integrity


### PR DESCRIPTION
A few little fixes and enhancements to the postgres one-click app.
Please see each commit message for descriptions of the changes.

Regarding the last commit (a2ccd72531794f78f9bc19bf941cd57c6dbe0a9f):
The current behavior (of post-fixing the user-given app name with "-db") is super annoying...
I would like to be able to specify an app name to be used unaltered.
I can choose an appropriate app name myself.
If I forget that this one-click app does this post-fixing, my app name ends up being something like "my-app-db-db", and I have to delete it and recreate it 

### ☑️ Self Check before Merge

- [X] I have tested the template using the method described in README.md thoroughly
- [X] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [X] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [X] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [X] Icon is added as a png file to the logos directory.
