### PR TITLE
feat(typebot): fix invalid path on typebot database

### DIFF
--- a/public/v4/apps/typebot.yml
+++ b/public/v4/apps/typebot.yml
@@ -79,7 +79,7 @@ services:
             POSTGRES_USER: $$cap_POSTGRES_USER
             POSTGRES_PASSWORD: $$cap_POSTGRES_PASSWORD
         volumes:
-            - $$cap_appname-db-data:/data/postgres
+            - $$cap_appname-db-data:/var/lib/postgresql/data
 
 caproverOneClickApp:
     instructions:


### PR DESCRIPTION
Hello there!

I had an issue deploying Typebot yesterday
According to postgres's image documentation, it's database volume was not binded in the right folder

Because of this we lost some data, here is a fix to prevent this from happening again 😊