### PR TITLE
update portainer to 2.16.2

### DIFF
--- a/public/v4/apps/portainer.yml
+++ b/public/v4/apps/portainer.yml
@@ -12,7 +12,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_portainer_version
           label: Portainer Version
-          defaultValue: 2.0.0
+          defaultValue: 2.16.2
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/portainer/portainer-ce/tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_portainer_edition


### PR DESCRIPTION
This exact template still works for the current latest version

I can use itself to check it is indeed using this very version 😄 

![Screenshot 2023-01-21 at 13 22 02](https://user-images.githubusercontent.com/23552631/213881564-a0a21058-f9dd-4955-8a04-b5bed90cf736.png)


