### PR TITLE
MinIO - Bumped version, tweaked API name + env, hardened root user keys, added endnotes

### DIFF
--- a/public/v4/apps/minio.yml
+++ b/public/v4/apps/minio.yml
@@ -23,6 +23,7 @@ services:
             - $$cap_appname
         environment:
             UPSTREAM_HTTP_ADDRESS: http://srv-captain--$$cap_appname:9000
+            CLIENT_MAX_BODY_SIZE: 0
 caproverOneClickApp:
     variables:
         - id: $$cap_minio_version

--- a/public/v4/apps/minio.yml
+++ b/public/v4/apps/minio.yml
@@ -10,7 +10,7 @@ services:
             MINIO_ROOT_PASSWORD: $$cap_secret_key
             MINIO_REGION_NAME: 'eu-east-1'
             MINIO_BROWSER_REDIRECT_URL: https://$$cap_appname.$$cap_root_domain
-            MINIO_SERVER_URL: https://$$cap_appname-s3.$$cap_root_domain # MinIO S3 API
+            MINIO_SERVER_URL: https://$$cap_appname-api.$$cap_root_domain # MinIO S3 API
         caproverExtra:
             containerHttpPort: '9001'
             dockerfileLines:
@@ -31,24 +31,45 @@ caproverOneClickApp:
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/minio/minio/tags/
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_access_key
-          label: MinIO Access Key
-          defaultValue: ''
-          description: Username to access MinIO server
-          validRegex: /.{5,}/
+          label: MinIO Root User Access Key
+          defaultValue: $$cap_gen_random_hex(24)
+          description: Access key for `MINIO_ROOT_USER`. If unset, minio defaults to `minioadmin`. MinIO strongly recommends specifying a unique, long, and random value for all environments.
+          validRegex: /(.{5,})|(^\s{0}$)/m
         - id: $$cap_secret_key
           label: Minio Secret Key
-          defaultValue: ''
-          description: Password to access MinIO server
-          validRegex: /.{8,}/
+          defaultValue: $$cap_gen_random_hex(38)
+          description: Secret key for `MINIO_ROOT_PASSWORD`. If unset, minio defaults to `minioadmin`. MinIO strongly recommends specifying a unique, long, and random value for all environments.
+          validRegex: /(.{8,})|(^\s{0}$)/m
     instructions:
         start: >-
             MinIO is a High Performance Object Storage released under GNU Affero General Public License v3.0. 
             It is API compatible with Amazon S3 cloud storage service.
-        end: >-
-            Minio is deployed and available as $$cap_appname. 
-            **Important**: Make sure to enable HTTPS and WEBSOCKETS for both $$cap_appname and $$cap_appname-s3
-            You can access the dashboard at https://$$cap_appname.$$cap_root_domain
-            And, you can access the S3 API Endpoint at https://$$cap_appname-api.$$cap_root_domain
+        end: |-
+
+            ✅  MinIO has been deployed!
+            --------------------------------------------
+            _MinIO has been successfully deployed! Be sure to read the next steps below before attempting to access https://$$cap_appname.$$cap_root_domain._
+
+            --------------------------------------------
+            ❗️ **IMPORTANT**: Before launching MinIO be sure to change the following settings:
+
+            **Step 1**: Go to the settings for `$$cap_appname` and `$$cap_appname-api`
+            **Step 2**: Enable **HTTPS**
+            **Step 3**: Enable **Websocket Support**
+
+            🔐 Dashboard access uses the keys set during deployment. If left blank, MinIO sets the keys by default to _minioadmin_.
+
+            **Access Key**: $$cap_access_key
+            **Secret Key**: $$cap_secret_key
+
+            🌐 After completing the steps above, you can access MinIO at:
+
+            **Dashboard**: https://$$cap_appname.$$cap_root_domain
+            **S3 API Endpoint**: https://$$cap_appname-api.$$cap_root_domain
+
+            --------------------------------------------
+            🔰 More information on initial configuration can be found at https://docs.min.io/docs/minio-docker-quickstart-guide.html
+
     displayName: 'MinIO'
     isOfficial: true
     description: MinIO is a cloud storage server compatible with Amazon S3

--- a/public/v4/apps/minio.yml
+++ b/public/v4/apps/minio.yml
@@ -16,7 +16,7 @@ services:
             dockerfileLines:
                 - FROM minio/minio:$$cap_minio_version
                 - CMD ["server", "/data", "--console-address", ":9001"]
-    $$cap_appname-s3:
+    $$cap_appname-api:
         image: caprover/nginx-reverse-proxy:1-ef5ffcb
         restart: always
         depends_on:
@@ -27,7 +27,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_minio_version
           label: MinIO Version
-          defaultValue: RELEASE.2021-08-17T20-53-08Z
+          defaultValue: RELEASE.2023-01-18T04-36-38Z
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/minio/minio/tags/
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_access_key
@@ -48,7 +48,7 @@ caproverOneClickApp:
             Minio is deployed and available as $$cap_appname. 
             **Important**: Make sure to enable HTTPS and WEBSOCKETS for both $$cap_appname and $$cap_appname-s3
             You can access the dashboard at https://$$cap_appname.$$cap_root_domain
-            And, you can access the S3 API Endpoint at https://$$cap_appname-s3.$$cap_root_domain
+            And, you can access the S3 API Endpoint at https://$$cap_appname-api.$$cap_root_domain
     displayName: 'MinIO'
     isOfficial: true
     description: MinIO is a cloud storage server compatible with Amazon S3


### PR DESCRIPTION
First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.

---
### 🆕 Changes

- [x] MinIO version bumped to `RELEASE.2023-01-18T04-36-38Z`
- [x] S3 API endpoint service named changed from `$$cap_appname-S3` to `$$cap_appname-api`
  - My reasoning was to enable users to name the main service `s3`--giving them an endpoint URL that is more consistent with generally accepted S3 storage standards--without then having the somewhat clumsy API endpoint URL `s3-s3`. This is a subjective choice, so if there is a preference for this to remain unchanged, I'm happy to change it back.
- [x] Changed default values for `Access Key` and `Secret Key` to adhere to MinIO documentation for `MINIO_ROOT_USER`. Specifically, I provided default settings of randomly generated 24-digit and 30-digit keys respectively, and modified the RegEx to allow for either empty or custom keys to be used.
- [x] Provided additional endnotes in order to:
  - Draw more attention to the required post-deployment steps
  - Provide users with authentication keys
  - Show URLs for each service
  - Provide a link to more documentation

### 🛠️ Fixed
- [x] Added `CLIENT_MAX_BODY_SIZE: 0` to API env, the image default was `20M` which prevents uploading any larger files.

---
✅ All changes have been tested and confirmed to operate as-expected.