### PR TITLE
Keycloak v20.0.3 + Fix db url issue

### DIFF
--- a/public/v4/apps/keycloak.yml
+++ b/public/v4/apps/keycloak.yml
@@ -35,7 +35,7 @@ services:
                 - ENV KC_DB_URL=jdbc:postgresql://srv-captain--$$cap_appname-db/keycloak
                 - ENV KC_DB_USERNAME=keycloak
                 - ENV KC_DB_PASSWORD=$$cap_pg_pass
-                - ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start", "--hostname=$$cap_appname.$$cap_root_domain", "--proxy=edge"]
+                - ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start", "--optimized --hostname=$$cap_appname.$$cap_root_domain", "--proxy=edge"]
 
 caproverOneClickApp:
     variables:
@@ -46,8 +46,8 @@ caproverOneClickApp:
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_keycloak_version
           label: Keycloak Version
-          defaultValue: 18.0.2
-          description: v18.0.2 current as of 2022-07-04.  Check out their Docker page for the valid tags https://quay.io/repository/keycloak/keycloak?tab=tags
+          defaultValue: 20.0.3
+          description: v20.0.3 current as of 2023-01-13.  Check out their Docker page for the valid tags https://quay.io/repository/keycloak/keycloak?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_pg_pass
           label: Postgres Password


### PR DESCRIPTION
Newer keycloak versions auto-build on `kc.sh start`. This leads to loss of correct usage of postgres db. If we pass `--optimized` parameter to it, keycloak will take the already build file with KC_DB=postgres and it should work.

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [x ] I have tested the template using the method described in README.md thoroughly
- [ x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [ x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x ] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ x] Icon is added as a png file to the logos directory.
