### PR TITLE
iRedMail: Fix spelling

### DIFF
--- a/public/v4/apps/iredmail.yml
+++ b/public/v4/apps/iredmail.yml
@@ -33,22 +33,22 @@ services:
                 - ARG FIRST_MAIL_DOMAIN_ADMIN_PASSWORD=1234
                 - ARG MLMMJADMIN_API_TOKEN
                 - ARG ROUNDCUBE_DES_KEY
-                - ARG ADMIN_VIRSION=NoChange
-                - ENV ADMIN_VIRSION=$ADMIN_VIRSION
+                - ARG ADMIN_VERSION=NoChange
+                - ENV ADMIN_VERSION=$ADMIN_VERSION
                 - ENV FIRST_MAIL_DOMAIN=$FIRST_MAIL_DOMAIN
                 - ENV HOSTNAME=$HOSTNAME
                 - ENV FIRST_MAIL_DOMAIN_ADMIN_PASSWORD=$FIRST_MAIL_DOMAIN_ADMIN_PASSWORD
                 - ENV MLMMJADMIN_API_TOKEN=$MLMMJADMIN_API_TOKEN
                 - ENV ROUNDCUBE_DES_KEY=ROUNDCUBE_DES_KEY
                 - >-
-                    RUN echo "if [\"$ADMIN_VIRSION\" != \"NoChange\" && \"$ADMIN_VIRSION\"
+                    RUN echo "if [\"$ADMIN_VERSION\" != \"NoChange\" && \"$ADMIN_VERSION\"
                     != \"\$(ls /opt/www/ | grep 'iRedAdmin-' | cut -d'-' -f2)\"]; then
                     wget -c -q
-                    https://github.com/iredmail/iRedAdmin/archive/$ADMIN_VIRSION.tar.gz &&
-                    tar xzf $ADMIN_VIRSION.tar.gz -C /opt/www && rm -f
-                    $ADMIN_VIRSION.tar.gz && cp -R -f /opt/www/iRedAdmin-$ADMIN_VIRSION/*
+                    https://github.com/iredmail/iRedAdmin/archive/$ADMIN_VERSION.tar.gz &&
+                    tar xzf $ADMIN_VERSION.tar.gz -C /opt/www && rm -f
+                    $ADMIN_VERSION.tar.gz && cp -R -f /opt/www/iRedAdmin-$ADMIN_VERSION/*
                     /opt/www/iredadmin && sleep 1; rm -r
-                    /opt/www/iRedAdmin-$ADMIN_VIRSION; fi" >> build.sh
+                    /opt/www/iRedAdmin-$ADMIN_VERSION; fi" >> build.sh
                 - RUN sh build.sh && rm build.sh
                 - >-
                     RUN cat /opt/www/iredadmin/templates/default/layout.html | replace
@@ -164,7 +164,7 @@ services:
             ROUNDCUBE_DES_KEY: $$cap_gen_random_hex(24)
             FIRST_MAIL_DOMAIN: $$cap_root_domain
             HOSTNAME: $$cap_appname.$$cap_root_domain
-            ADMIN_VIRSION: $$cap_iredmail_admin_version
+            ADMIN_VERSION: $$cap_iredmail_admin_version
             FIRST_MAIL_DOMAIN_ADMIN_PASSWORD: $$cap_iredmail_default_password
 caproverOneClickApp:
     variables:

--- a/public/v4/apps/iredmail.yml
+++ b/public/v4/apps/iredmail.yml
@@ -172,7 +172,7 @@ caproverOneClickApp:
           label: iRedMail version tag
           description: >-
               Check out their Docker page for the valid tags
-              https://hub.docker.com/r/iredmail/mariadb/tag
+              https://hub.docker.com/r/iredmail/mariadb/tags
           defaultValue: stable
         - id: $$cap_iredmail_admin_version
           label: iRedMail Admin version tag
@@ -180,7 +180,7 @@ caproverOneClickApp:
               Set 'NoChange' to stay by the docker image version
               OR
               Check out their GitHub page for the newest version
-              https://github.com/iredmail/iRedAdmin/releases
+              https://github.com/iredmail/iRedAdmin/tags
           defaultValue: NoChange
         - id: $$cap_iredmail_default_password
           label: First Password


### PR DESCRIPTION
I just fixed the spelling of an ENV Var


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
