### PR TITLE
fix(chatwoot): Missing host to link to! Please provide the :host parameter

### DIFF
--- a/public/v4/apps/chatwoot.yml
+++ b/public/v4/apps/chatwoot.yml
@@ -48,6 +48,7 @@ services:
         environment:
             RAILS_ENV: production
             RAILS_LOG_TO_STDOUT: 'true'
+            FRONTEND_URL: http://$$cap_appname.$$cap_root_domain
             SECRET_KEY_BASE: $$cap_chatwoot_secret_key_base
             POSTGRES_HOST: srv-captain--$$cap_appname-postgres
             POSTGRES_DATABASE: chatwoot
@@ -68,7 +69,7 @@ caproverOneClickApp:
         - id: $$cap_chatwoot_version
           label: Chatwoot Version Tag
           description: Choose the latest version from https://hub.docker.com/r/chatwoot/chatwoot/tags
-          defaultValue: v2.7.0
+          defaultValue: v2.16.0
         - id: $$cap_chatwoot_secret_key_base
           label: Chatwoot Secret Key Base
           description: The randomized string which is used to verify the integrity of signed cookies. Please use a string with more than 26 characters


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

When I install one-click chatwoot and play, I got the error `ActionView::Template::Error (Missing host to link to! Please provide the :host parameter, set default_url_options[:host],`. So the solution is add environment variable `FRONTEND_URL` to get it works as https://github.com/chatwoot/chatwoot/issues/5707#issuecomment-1287271013


### ☑️ Self Check before Merge

- [ ☑️] I have tested the template using the method described in README.md thoroughly
- [ ☑️] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [ ☑️] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [ ☑️] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ☑️] Icon is added as a png file to the logos directory.
- [ ☑️] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [ ☑️] I will take resposibility addressing any issues that arises as a result of this PR (maintaining this app).
