### PR TITLE
#942 - Penpot - adding environment variables to frontend

### DIFF
--- a/public/v4/apps/penpot.yml
+++ b/public/v4/apps/penpot.yml
@@ -90,7 +90,7 @@ caproverOneClickApp:
           description: Checkout their docker description page for the valid tags https://hub.docker.com/_/redis?tab=description
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_penpot_version
-          label: Penpot Frontend Version
+          label: Penpot version for frontend, backend and exporter
           defaultValue: '1.18.4'
           description: Checkout their docker page for the valid tags https://hub.docker.com/r/penpotapp/frontend/tags
           validRegex: /^([^\s^\/])+$/

--- a/public/v4/apps/penpot.yml
+++ b/public/v4/apps/penpot.yml
@@ -70,11 +70,8 @@ services:
             - $$cap_appname-assets-data:/opt/data
         environment:
             PENPOT_FLAGS: $$cap_flags
-        caproverExtra:
-            dockerfileLines:
-                - FROM penpotapp/frontend:$$cap_penpot_frontend_version
-                - RUN sed -i 's/penpot-backend/srv-captain--$$cap_appname-backend/g' /etc/nginx/nginx.conf
-                - RUN sed -i 's/penpot-exporter/srv-captain--$$cap_appname-exporter/g' /etc/nginx/nginx.conf
+            PENPOT_BACKEND_URI: http://srv-captain--$$cap_appname-backend:6060
+            PENPOT_EXPORTER_URI: http://srv-captain--$$cap_appname-exporter:6061
         depends_on:
             - $$cap_appname-backend
             - $$cap_appname-exporter

--- a/public/v4/apps/penpot.yml
+++ b/public/v4/apps/penpot.yml
@@ -66,6 +66,7 @@ services:
 
     # Frontend
     $$cap_appname:
+        image: penpotapp/frontend:$$cap_penpot_frontend_version
         volumes:
             - $$cap_appname-assets-data:/opt/data
         environment:

--- a/public/v4/apps/penpot.yml
+++ b/public/v4/apps/penpot.yml
@@ -24,7 +24,7 @@ services:
 
     # Exporter
     $$cap_appname-exporter:
-        image: penpotapp/exporter:$$cap_penpot_exporter_version
+        image: penpotapp/exporter:$$cap_penpot_version
         restart: always
         environment:
             PENPOT_PUBLIC_URI: $$cap_public_uri
@@ -34,7 +34,7 @@ services:
 
     # Backend
     $$cap_appname-backend:
-        image: penpotapp/backend:$$cap_penpot_backend_version
+        image: penpotapp/backend:$$cap_penpot_version
         volumes:
             - $$cap_appname-assets-data:/opt/data
         environment:
@@ -66,7 +66,7 @@ services:
 
     # Frontend
     $$cap_appname:
-        image: penpotapp/frontend:$$cap_penpot_frontend_version
+        image: penpotapp/frontend:$$cap_penpot_version
         volumes:
             - $$cap_appname-assets-data:/opt/data
         environment:
@@ -81,28 +81,18 @@ caproverOneClickApp:
     variables:
         - id: $$cap_postgres_version
           label: Postgres Version
-          defaultValue: '13'
+          defaultValue: '15'
           description: Checkout their docker description page for the valid tags https://hub.docker.com/_/postgres?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_redis_version
           label: Redis Version
-          defaultValue: '6'
+          defaultValue: '7'
           description: Checkout their docker description page for the valid tags https://hub.docker.com/_/redis?tab=description
           validRegex: /^([^\s^\/])+$/
-        - id: $$cap_penpot_frontend_version
+        - id: $$cap_penpot_version
           label: Penpot Frontend Version
-          defaultValue: '1.15.2-beta'
+          defaultValue: '1.18.4'
           description: Checkout their docker page for the valid tags https://hub.docker.com/r/penpotapp/frontend/tags
-          validRegex: /^([^\s^\/])+$/
-        - id: $$cap_penpot_backend_version
-          label: Penpot Backend Version
-          defaultValue: '1.15.2-beta'
-          description: Checkout their docker page for the valid tags https://hub.docker.com/r/penpotapp/backend/tags
-          validRegex: /^([^\s^\/])+$/
-        - id: $$cap_penpot_exporter_version
-          label: Penpot Exporter Version
-          defaultValue: '1.15.2-beta'
-          description: Checkout their docker page for the valid tags https://hub.docker.com/r/penpotapp/exporter/tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_flags
           label: Penpot Flags


### PR DESCRIPTION
Fixes #942 

Nginx config can no longer be updated with custom `sed` commands in docker image as it is created by penpot image upon startup. 

However environmen variables are now supported to configure the backend and exporter URI so update to those instead.
