### PR TITLE
Update directus-mysql-redis.yml

### DIFF
--- a/public/v4/apps/directus-mysql-redis.yml
+++ b/public/v4/apps/directus-mysql-redis.yml
@@ -42,9 +42,12 @@ services:
             DB_PASSWORD: $$cap_mysql_password
             CACHE_ENABLED: 'true'
             CACHE_STORE: 'redis'
-            CACHE_REDIS: redis://srv-captain--$$cap_appname-redis:6379
             CACHE_AUTO_PURGE: $$cap_redis_auto_purge
             CACHE_TTL: $$cap_redis_ttl
+            # Before Directus 10.4.0
+            CACHE_REDIS: redis://srv-captain--$$cap_appname-redis:6379
+            # Since Directus 10.4.0
+            REDIS: redis://srv-captain--$$cap_appname-redis:6379
             ADMIN_EMAIL: $$cap_admin_email
             ADMIN_PASSWORD: $$cap_admin_password
             TELEMETRY: 'false'


### PR DESCRIPTION
Since Directus 10.4.0 we need to use the `REDIS` env var instead of `CACHE_REDIS`. By keeping both vars it will work for previous as well as for future versions.