### PR TITLE
Updated orangehrm to use orangehrm/orangehrm

### DIFF
--- a/public/v4/apps/orangehrm.yml
+++ b/public/v4/apps/orangehrm.yml
@@ -14,12 +14,12 @@ services:
         caproverExtra:
             notExposeAsWebApp: 'true'
     $$cap_appname:
-        documentation: Taken from https://hub.docker.com/r/bitnami/orangehrm
+        documentation: Taken from https://hub.docker.com/r/orangehrm/orangehrm
         depends_on:
             - $$cap_appname-db
-        image: bitnami/orangehrm:$$cap_orangehrm_version
+        image: orangehrm/orangehrm:$$cap_orangehrm_version
         volumes:
-            - $$cap_appname-data:/bitnami
+            - $$cap_appname-data:/orangehrm
         restart: always
         environment:
             ORANGEHRM_USERNAME: $$cap_admin_name
@@ -32,6 +32,8 @@ services:
             SMTP_PORT: $$cap_smtp_port
             SMTP_USER: $$cap_smtp_user
             SMTP_PASSWORD: $$cap_smtp_pass
+            PUID: 998
+            PGID: 100
 caproverOneClickApp:
     variables:
         - id: $$cap_admin_name
@@ -45,12 +47,12 @@ caproverOneClickApp:
           validRegex: /.{1,}/
         - id: $$cap_orangehrm_version
           label: OrangeHRM Version
-          defaultValue: '4.6.0-0'
+          defaultValue: '5.4'
           description: https://hub.docker.com/r/bitnami/orangehrm/tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_mariadb_version
           label: MariaDB (database) version
-          defaultValue: 10.5.3
+          defaultValue: 10.11.4
           description: Check out their Docker page for the valid tags https://hub.docker.com/_/mariadb?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_db_pass


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

This PR updates Orangehrm. It was previously using bitnami/orangehrm which no longer exists, hence breaking the app. I updated it to use orangehrm/orangehrm instead

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
