### PR TITLE
Updated PrivateBin to 1.5.1. Added persistent config volume

### DIFF
--- a/public/v4/apps/privatebin.yml
+++ b/public/v4/apps/privatebin.yml
@@ -7,13 +7,14 @@ services:
             PHP_TZ: '$$cap_tz'
         volumes:
             - '$$cap_appname-data:/srv/data'
+            - '$$cap_appname-cfg:/srv/cfg'
         caproverExtra:
             containerHttpPort: '8080'
 caproverOneClickApp:
     variables:
         - id: '$$cap_version'
           label: PrivateBin Version
-          defaultValue: '1.3.4'
+          defaultValue: '1.5.1'
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/privatebin/nginx-fpm-alpine/tags
           validRegex: "/^([^\\s^\\/])+$/"
         - id: '$$cap_tz'


### PR DESCRIPTION
## Changes
- Updated PrivateBin to version 1.5.1 (see [tags](https://hub.docker.com/r/privatebin/nginx-fpm-alpine/tags))
- Added volume for the config folder to allow overriding PrivateBin configurations. See [configuration](https://github.com/PrivateBin/PrivateBin/wiki/Configuration) for documentation. 

By default the config folder is completely empty, so it wont affect existing or new deployments. It will, however, allow us to add our own `conf.php` based on their template.  

### Help Wanted

If there is a way to edit/add config from within CapRover without needing to SSH into the server and manually create a `conf.php` file, **please let me know**. 

PrivateBin have [configuration file sample](https://raw.githubusercontent.com/PrivateBin/PrivateBin/master/cfg/conf.sample.php) that would be perfect as a can use as a placeholder, with everything that is non-default is commented out. This would be the ideal way to manage custom config. :cat2: 

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
