### PR TITLE
feat(wordpress, wordpress-only): use generated default password

### DIFF
--- a/public/v4/apps/wordpress-only.yml
+++ b/public/v4/apps/wordpress-only.yml
@@ -32,6 +32,7 @@ caproverOneClickApp:
           label: Database password
           description: ''
           validRegex: /.{1,}/
+          defaultValue: $$cap_gen_random_hex(16)
         - id: $$cap_wp_version
           label: WordPress Version
           defaultValue: 5.4.0

--- a/public/v4/apps/wordpress.yml
+++ b/public/v4/apps/wordpress.yml
@@ -33,6 +33,7 @@ caproverOneClickApp:
           label: Database password
           description: ''
           validRegex: /^(\w|[^\s"'\\])+$/
+          defaultValue: $$cap_gen_random_hex(16)
         - id: $$cap_wp_version
           label: WordPress Version
           defaultValue: '6.0.1'


### PR DESCRIPTION
This pull request adds randomly generated default database passwords to the Wordpress one-click-applications.

## Checks

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
