### PR TITLE
feat(mixpost): add https hint

### DIFF
--- a/public/v4/apps/mixpost.yml
+++ b/public/v4/apps/mixpost.yml
@@ -52,6 +52,7 @@ caproverOneClickApp:
             Mixpost has been successfully deployed! It might take few moments before it's fully started.
             You can access the application at `http://$$cap_appname.$$cap_root_domain`.
             Find the administrator login details in the logs.
+            If you enabled HTTPS, you should adjust the `APP_URL` environment variable accordingly.
     variables:
         - id: $$cap_MIXPOST_VERSION
           label: Application | Version


### PR DESCRIPTION
This pull request updates the Mixpost one-click-application by adding a hint about HTTPS to the end instructions.
Caused by https://github.com/caprover/one-click-apps/pull/889#issuecomment-1634898745.

## Checks

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
