### PR TITLE
chore: update chatwoot.yml to use v3 and postgres15

### DIFF
--- a/public/v4/apps/chatwoot.yml
+++ b/public/v4/apps/chatwoot.yml
@@ -69,7 +69,7 @@ caproverOneClickApp:
         - id: $$cap_chatwoot_version
           label: Chatwoot Version Tag
           description: Choose the latest version from https://hub.docker.com/r/chatwoot/chatwoot/tags
-          defaultValue: v3.0.0
+          defaultValue: v3.1.1
         - id: $$cap_chatwoot_secret_key_base
           label: Chatwoot Secret Key Base
           description: The randomized string which is used to verify the integrity of signed cookies. Please use a string with more than 26 characters

--- a/public/v4/apps/chatwoot.yml
+++ b/public/v4/apps/chatwoot.yml
@@ -1,7 +1,7 @@
 captainVersion: 4
 services:
     $$cap_appname-postgres:
-        image: postgres:12
+        image: postgres:15
         volumes:
             - $$cap_appname-postgres-data:/var/lib/postgresql/data
         restart: always
@@ -69,7 +69,7 @@ caproverOneClickApp:
         - id: $$cap_chatwoot_version
           label: Chatwoot Version Tag
           description: Choose the latest version from https://hub.docker.com/r/chatwoot/chatwoot/tags
-          defaultValue: v2.16.0
+          defaultValue: v3.0.0
         - id: $$cap_chatwoot_secret_key_base
           label: Chatwoot Secret Key Base
           description: The randomized string which is used to verify the integrity of signed cookies. Please use a string with more than 26 characters


### PR DESCRIPTION

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.

### Changelog
- Update Chatwoot version to v3.1.1. and postgres version to 15

### ☑️ Self Check before Merge

- [ ] I have tested the template using the method described in README.md thoroughly
- [ ] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [ ] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [ ] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] Icon is added as a png file to the logos directory.
- [ ] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [ ] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
