### PR TITLE
Update Shiori

### DIFF
--- a/public/v4/apps/shiori.yml
+++ b/public/v4/apps/shiori.yml
@@ -11,7 +11,6 @@ services:
             SHIORI_MYSQL_ADDRESS: tcp(srv-captain--$$cap_appname-mariadb)
         volumes:
             - $$cap_appname-data:/shiori
-        restart: unless-stopped
         caproverExtra:
             containerHttpPort: '8080'
     # MariaDB

--- a/public/v4/apps/shiori.yml
+++ b/public/v4/apps/shiori.yml
@@ -48,6 +48,7 @@ caproverOneClickApp:
         - id: $$cap_mariadb-pass
           label: MariaDB database user password
           description: Super secret database user password
+          defaultValue: $$cap_gen_random_hex(16)
     displayName: 'Shiori'
     isOfficial: true
     description: 'A simple bookmark manager built with Go.'


### PR DESCRIPTION
Just a small update based on your suggestion at #[973](https://github.com/caprover/one-click-apps/pull/973#discussion_r1280052539_)

My apologies for the late update

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
