### PR TITLE
Update sshd.yml, enables ssh tunneling by defaul

### DIFF
--- a/public/v4/apps/sshd.yml
+++ b/public/v4/apps/sshd.yml
@@ -7,6 +7,7 @@ services:
             PGID: 1001
             TZ: Europe/London
             PUBLIC_KEY: $$cap_sshd_public_key
+            DOCKER_MODS: linuxserver/mods:openssh-server-ssh-tunnel
             # USER_PASSWORD: $$cap_sshd_public_key
             # - PUBLIC_KEY_FILE=/path/to/file #optional
             # - PUBLIC_KEY_DIR=/path/to/directory/containing/_only_/pubkeys #optional
@@ -48,8 +49,6 @@ caproverOneClickApp:
 
             ssh -i /path/to/private.key $$cap_sshd_username@$$cap_appname.$$cap_root_domain -p $$cap_sshd_port
 
-
-            ** SSH Port Forwarding Rules ** might need to be manually added, see [here](https://github.com/caprover/caprover/issues/960#issuecomment-1027826772)
     displayName: SSH Container
     isOfficial: true
     description: Just a simple container that has sshd installed so you can SSH directly into this container.


### PR DESCRIPTION
Updates a ENV var so that the openssh-server enables by default the ssh tunneling.

The docs says that the SSH one-click install should be the one used for tunneling, but somehow this pinned version ships with the `AllowTcpForwarding  no`  and that makes no sense in this context.

The easy fix is to add this one-liner to the ENV variables:

`DOCKER_MODS=linuxserver/mods:openssh-server-ssh-tunnel`

As suggested here: https://github.com/linuxserver/docker-openssh-server/issues/43#issuecomment-1238950477

Thanks a lot!