### PR TITLE
update readme and an app to show websocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ caproverOneClickApp:
     - `dockerfileLines` which is a multiline variable, and can be used instead of `image` property in the service. You must delete the `image` property if you want to use this parameter.
     - `containerHttpPort` is useful when the underlying service uses a custom port for HTTP. If not provided, the default will be `"80"`
     - `notExposeAsWebApp` can be set to `"true"` when the underlying service is not an HTTP app. This is useful for databases and other internally used services.
-    - `websocketSupport` can be set to `"true"` to automatically enable Websocket Support.
+    - `websocketSupport` can be set to `"true"` to automatically enable Websocket Support. Only supported in versions 1.12+
 
 ### Icon
 - Make sure you add an app icon to the logos directory!

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ caproverOneClickApp:
     - `dockerfileLines` which is a multiline variable, and can be used instead of `image` property in the service. You must delete the `image` property if you want to use this parameter.
     - `containerHttpPort` is useful when the underlying service uses a custom port for HTTP. If not provided, the default will be `"80"`
     - `notExposeAsWebApp` can be set to `"true"` when the underlying service is not an HTTP app. This is useful for databases and other internally used services.
+    - `websocketSupport` can be set to `"true"` to automatically enable Websocket Support.
 
 ### Icon
 - Make sure you add an app icon to the logos directory!

--- a/public/v4/apps/uptime-kuma.yml
+++ b/public/v4/apps/uptime-kuma.yml
@@ -8,6 +8,7 @@ services:
             - $$cap_appname-data:/app/data
         caproverExtra:
             containerHttpPort: '3001'
+            websocketSupport: 'true'
 caproverOneClickApp:
     variables:
         - id: $$cap_kuma_version


### PR DESCRIPTION
I created an app with the one-click-app database recently and websocket support was not checked by default. This caused the app to not work appropriately until that was enabled. I posted in slack about this and was encouraged to submit a pull request. Please let me know if any adjustments need to be made. 

I've created a [pull request on the front end repo](https://github.com/caprover/caprover-frontend/pull/132) in order to handle this variable. It will enable the websocket support automatically if `true`. 

Websocket can be checked by adding a property like the following into the template: 

```yml
services:
    $$cap_appname:
        ...

        caproverExtra:
            websocketSupport: 'true'

        ...
```

I tested to ensure this was not a breaking change, and was an opt in only type of feature. From my testing this is friendly to templates with or without the variable.
