### PR TITLE
fix supabase-postgresql volume

### DIFF
--- a/public/v4/apps/supabase-postgres.yml
+++ b/public/v4/apps/supabase-postgres.yml
@@ -3,7 +3,7 @@ services:
     $$cap_appname-db:
         image: bitnami/supabase-postgres:$$cap_app_version
         volumes:
-            - $$cap_appname-db-data:/var/lib/postgresql/data
+            - $$cap_appname-db-persistence:/bitnami/postgresql
         restart: always
         environment:
             POSTGRES_USER: $$cap_pg_user


### PR DESCRIPTION
I just noticed bitnami images uses a different path /bitnami/postgresql for the postgres data and not the standard /var/lib/postgresql/data.
This fixes the bitnami based supabase-postgres app which currently has incorrect volume mapped, so anyone with the current one will loose data on container reboot.

The bug was introduced in https://github.com/caprover/one-click-apps/pull/993

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
