### PR TITLE
Update plausible.yml to v2

### DIFF
--- a/public/v4/apps/plausible.yml
+++ b/public/v4/apps/plausible.yml
@@ -3,7 +3,6 @@ captainVersion: 4
 services:
     $$cap_appname-mail:
         image: bytemark/smtp
-        restart: always
         environment:
             RELAY_HOST: $$cap_RELAY_HOST
             RELAY_PORT: $$cap_RELAY_PORT
@@ -23,7 +22,7 @@ services:
             notExposeAsWebApp: 'true'
 
     $$cap_appname-clickhouse:
-        image: yandex/clickhouse-server:$$cap_CLICKHOUSE_VERSION
+        image: clickhouse/clickhouse-server:$$cap_CLICKHOUSE_VERSION
         volumes:
             - $$cap_appname-clickhouse-data:/var/lib/clickhouse
         caproverExtra:
@@ -38,39 +37,19 @@ services:
             containerHttpPort: '8000'
             dockerfileLines:
                 - FROM plausible/analytics:$$cap_PLAUSIBLE_VERSION
-                - CMD ["sh", "-c", "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run"]
+                - CMD ["sh", "-c", "sleep 10 && /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run"]
         environment:
-            ADMIN_USER_EMAIL: $$cap_ADMIN_USER_EMAIL
-            ADMIN_USER_NAME: $$cap_ADMIN_USER_NAME
-            ADMIN_USER_PWD: $$cap_ADMIN_USER_PWD
             BASE_URL: http://$$cap_appname.$$cap_root_domain
+            SECRET_KEY_BASE: $$cap_gen_random_hex(64)
             DATABASE_URL: postgres://plausible:$$cap_POSTGRES_PASSWORD@srv-captain--$$cap_appname-postgres:5432/plausible
             CLICKHOUSE_DATABASE_URL: http://srv-captain--$$cap_appname-clickhouse:8123/plausible
-            SECRET_KEY_BASE: $$cap_gen_random_hex(64)
-            SIGNING_SALT: $$cap_gen_random_hex(24)
             DISABLE_REGISTRATION: 'true'
-            DISABLE_SUBSCRIPTION: 'true'
             MAILER_EMAIL: $$cap_RELAY_USERNAME
             SMTP_HOST_ADDR: srv-captain--$$cap_appname-mail
             SMTP_HOST_PORT: '25'
 
 caproverOneClickApp:
     variables:
-        - defaultValue: 'admin@example.com'
-          description: This is the admin email. Please change it.
-          id: $$cap_ADMIN_USER_EMAIL
-          label: ADMIN_USER_EMAIL
-          validRegex: /^([^\s^\/])+$/
-        - defaultValue: 'admin'
-          description: This is the admin username. Please change it.
-          id: $$cap_ADMIN_USER_NAME
-          label: ADMIN_USER_NAME
-          validRegex: /^([^\s^\/])+$/
-        - defaultValue: 'password'
-          description: This is the admin password. Please change it.
-          id: $$cap_ADMIN_USER_PWD
-          label: ADMIN_USER_PWD
-          validRegex: /^([^\s^\/])+$/
         - defaultValue: 'plausible'
           description: This is the PostgreSQL password for user 'plausible'. Please change it.
           id: $$cap_POSTGRES_PASSWORD
@@ -93,20 +72,20 @@ caproverOneClickApp:
           id: $$cap_RELAY_PASSWORD
           label: RELAY_PASSWORD
           validRegex: /^([^\s^\/])+$/
-        - description: The version of Plausible docker image (from https://hub.docker.com/r/plausible/analytics/tags eg. v1 or v1.4)
+        - description: The version of Plausible docker image (from https://hub.docker.com/r/plausible/analytics/tags e.g. v2.0)
           id: $$cap_PLAUSIBLE_VERSION
           label: PLAUSIBLE_VERSION
-          defaultValue: v1
+          defaultValue: v2.0
           validRegex: /^([^\s^\/])+$/
-        - description: Clickhouse version (from https://hub.docker.com/r/yandex/clickhouse-server/tags, eg 21.12.2.17)
+        - description: Clickhouse version (from https://hub.docker.com/r/clickhouse/clickhouse-server/tags, e.g. 23.3.7.5-alpine)
           id: $$cap_CLICKHOUSE_VERSION
           label: CLICKHOUSE_VERSION
-          defaultValue: 21.3.2.5
+          defaultValue: 23.3.7.5-alpine
           validRegex: /^([^\s^\/])+$/
-        - description: Postgres version (from https://hub.docker.com/_/postgres?tab=tags, eg 12 or 12-alpine)
+        - description: Postgres version (from https://hub.docker.com/_/postgres?tab=tags, supported versions are 12, 13, and 14)
           id: $$cap_POSTGRES_VERSION
           label: POSTGRES_VERSION
-          defaultValue: 12-alpine
+          defaultValue: 14-alpine
           validRegex: /^([^\s^\/])+$/
     instructions:
         start: >-
@@ -116,7 +95,7 @@ caproverOneClickApp:
             - official image from https://hub.docker.com/r/plausible/analytics
             - https://hub.docker.com/r/bytemark/smtp, that allows linked containers to send outgoing email
             - official PostgreSQL image based on Alpine Linux and
-            - ClickHouse image https://hub.docker.com/r/yandex/clickhouse-server.
+            - ClickHouse image https://hub.docker.com/r/clickhouse/clickhouse-server.
             This version includes an open source geoip database (db-ip). If you would like to use Maxmind db,
             You will need to mount a volume and an additional container to update the database. You can use this docker
             compose file for reference: https://github.com/plausible/hosting/blob/master/geoip/docker-compose.geoip.yml
@@ -125,10 +104,10 @@ caproverOneClickApp:
             In case you add a new domain to your application, remember to set the environment variable BASE_URL accordingly.
 
             See https://github.com/plausible/analytics/blob/master/config/runtime.exs for all configurable
-            environment variables, for features like Google search, postmark, and slack integrations.
+            environment variables, for features like Google search, Postmark, and Slack integrations.
 
             IMPORTANT: It will take up to 2 minutes for Plausible to be ready. Before that, you might see 502 error page.
-    displayName: Plausible
+    displayName: Plausible v2
     isOfficial: false
     description: Plausible is a lightweight and open-source website analytics tool.
     documentation: Taken from https://plausible.io/.


### PR DESCRIPTION
Updated the Plausible one-click-app to match the current official `docker-compose.yml` from https://github.com/plausible/hosting

Removed unsupported env variables based on: https://plausible.io/docs/self-hosting-configuration

I've put in my custom repo: https://github.com/infomiho/one-click-apps and deployed it successfully on my CapRover instance.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
