### PR TITLE
Update pyload to a none deprecated container

### DIFF
--- a/public/v4/apps/pyload.yml
+++ b/public/v4/apps/pyload.yml
@@ -1,25 +1,25 @@
 captainVersion: 4
 services:
     $$cap_appname:
-        image: linuxserver/pyload:$$cap_pyload_version
+        image: lscr.io/linuxserver/pyload-ng:$$cap_pyload_version
         environment:
             TZ: $$cap_tz
-            PUID: '1000'
-            GUID: '1000'
+            PUID: $$cap_puid
+            PGID: $$cap_guid
         hostname: $$cap_appname.$$cap_root_domain
         volumes:
             - $$cap_appname-config:/config
             - $$cap_path_to_downloads:/downloads
         ports:
-            - 7227:7227
+            - 9666:9666
         caproverExtra:
             containerHttpPort: '8000'
 caproverOneClickApp:
     variables:
         - id: $$cap_pyload_version
           label: Pyload Version
-          defaultValue: 345921b3-ls4
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/linuxserver/pyload/tags
+          defaultValue: 0.5.0
+          description: Check out their Docker page for the valid tags https://github.com/linuxserver/docker-pyload-ng/pkgs/container/pyload-ng
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_tz
           label: Time Zone
@@ -31,15 +31,24 @@ caproverOneClickApp:
           defaultValue: pyload-downloads
           description: Path to pictures folder where u want to save the downloaded files. You can mention an existing directory here too. Eg. /home/user/downloads/
           validRegex: '/.{1,}/'
+        - id: $$cap_puid
+          label: User ID
+          defaultValue: '1000'
+          description: User ID that the process uses, run (id $user) in your instance to see the id
+          validRegex: /.{1,}/
+        - id: $$cap_guid
+          label: Group ID
+          defaultValue: '1000'
+          description: Group ID that the process uses, run (id $user) in your instance to see the id
+          validRegex: /.{1,}/
     instructions:
         start: >-
             Pyload is a Free and Open Source download manager written in Python and designed to be extremely lightweight, easily extensible and fully manageable via web.
         end: |-
-            Access the web interface at http://$$cap_appname.$$cap_root_domain the default login is: username - admin password - password
-            For the ng tag, the default user/pass are pyload/pyload.
+            Access the web interface at http://$$cap_appname.$$cap_root_domain the default login is: username - pyload & password - pyload
             For general usage please see the pyLoad wiki (https://github.com/pyload/pyload/wiki)
 
     displayName: Pyload
     isOfficial: true
-    description: Pyload - Free and Open Source download manager written in Python and designed to be extremely lightweight, easily extensible and fully manageable via web
-    documentation: Taken from https://hub.docker.com/r/linuxserver/pyload. Official Website is https://pyload.net/
+    description: The free and open-source Download Manager written in pure Python
+    documentation: Taken from https://docs.linuxserver.io/images/docker-pyload-ng/ Official Website is https://pyload.net/


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
