### PR TITLE
Update alternate repository URLs to caproverhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,5 @@ In order to add a third party repository:
 -   Click the **_Connect New Repository_** button
 
 #### 3rd party repositorie
--   Awes0meHub: [Github](https://github.com/Awes0meHub/caprover-one-click-apps) repository: `https://Awes0meHub.github.io/caprover-one-click-apps`
+-   Awes0meHub: [Github](https://github.com/caproverhub/caprover-one-click-apps) repository: `https://caproverhub.github.io/caprover-one-click-apps`
 -   Jordan-hall: [Github](https://github.com/Jordan-Hall/caprover-one-click-apps) repository: `https://oneclickapps.libertyware.io`


### PR DESCRIPTION

Since https://github.com/caproverhub/caprover-one-click-apps/commit/12fb993c79134423e3039828fbd75dffdc3bc41a
