### PR TITLE
feat(typebot): update to version 2.22.2 and simplify

### DIFF
--- a/public/v4/apps/typebot.yml
+++ b/public/v4/apps/typebot.yml
@@ -10,63 +10,39 @@ services:
             NEXT_PUBLIC_VIEWER_URL: http://$$cap_appname-viewer.$$cap_root_domain
             ENCRYPTION_SECRET: $$cap_TYPEBOT_ENCRYPTION_SECRET
             ADMIN_EMAIL: $$cap_TYPEBOT_ADMIN_EMAIL
+            NEXTAUTH_URL_INTERNAL: http://srv-captain--$$cap_appname-builder:3000
+            DEFAULT_WORKSPACE_PLAN: $$cap_TYPEBOT_DEFAULT_WORKSPACE_PLAN
             DISABLE_SIGNUP: $$cap_TYPEBOT_DISABLE_SIGNUP
             SMTP_USERNAME: $$cap_TYPEBOT_SMTP_USERNAME
             SMTP_PASSWORD: $$cap_TYPEBOT_SMTP_PASSWORD
             SMTP_HOST: $$cap_TYPEBOT_SMTP_HOST
             SMTP_PORT: $$cap_TYPEBOT_SMTP_PORT
-            NEXT_PUBLIC_SMTP_FROM: $$cap_TYPEBOT_SMTP_FROM
+            NEXT_PUBLIC_SMTP_FROM: $$cap_TYPEBOT_NEXT_PUBLIC_SMTP_FROM
             SMTP_SECURE: $$cap_TYPEBOT_SMTP_SECURE
             SMTP_AUTH_DISABLED: $$cap_TYPEBOT_SMTP_AUTH_DISABLED
-            GOOGLE_CLIENT_ID: $$cap_TYPEBOT_GOOGLE_CLIENT_ID
-            GOOGLE_CLIENT_SECRET: $$cap_TYPEBOT_GOOGLE_CLIENT_SECRET
-            NEXT_PUBLIC_GOOGLE_API_KEY: $$cap_TYPEBOT_GOOGLE_API_KEY
-            GITHUB_CLIENT_ID: $$cap_TYPEBOT_GITHUB_CLIENT_ID
-            GITHUB_CLIENT_SECRET: $$cap_TYPEBOT_GITHUB_CLIENT_SECRET
-            GITLAB_CLIENT_ID: $$cap_TYPEBOT_GITLAB_CLIENT_ID
-            GITLAB_CLIENT_SECRET: $$cap_TYPEBOT_GITLAB_CLIENT_SECRET
-            GITLAB_BASE_URL: $$cap_TYPEBOT_GITLAB_BASE_URL
-            GITLAB_REQUIRED_GROUPS: $$cap_TYPEBOT_GITLAB_REQUIRED_GROUPS
-            GITLAB_NAME: $$cap_TYPEBOT_GITLAB_NAME
-            FACEBOOK_CLIENT_ID: $$cap_TYPEBOT_FACEBOOK_CLIENT_ID
-            FACEBOOK_CLIENT_SECRET: $$cap_TYPEBOT_FACEBOOK_CLIENT_SECRET
-            AZURE_AD_CLIENT_ID: $$cap_TYPEBOT_AZURE_AD_CLIENT_ID
-            AZURE_AD_CLIENT_SECRET: $$cap_TYPEBOT_AZURE_AD_CLIENT_SECRET
-            AZURE_AD_TENANT_ID: $$cap_TYPEBOT_AZURE_AD_TENANT_ID
-            S3_ACCESS_KEY: $$cap_TYPEBOT_S3_ACCESS_KEY
-            S3_SECRET_KEY: $$cap_TYPEBOT_S3_SECRET_KEY
-            S3_BUCKET: $$cap_TYPEBOT_S3_BUCKET
-            S3_PORT: $$cap_TYPEBOT_S3_PORT
-            S3_ENDPOINT: $$cap_TYPEBOT_S3_ENDPOINT
-            S3_SSL: $$cap_TYPEBOT_S3_SSL
-            S3_REGION: $$cap_TYPEBOT_S3_REGION
-            NEXT_PUBLIC_GIPHY_API_KEY: $$cap_TYPEBOT_GIPHY_API_KEY
         depends_on:
             - $$cap_appname-db
+
     $$cap_appname-viewer:
         caproverExtra:
             containerHttpPort: 3000
         image: baptistearno/typebot-viewer:$$cap_TYPEBOT_VERSION
         environment:
             DATABASE_URL: postgresql://$$cap_POSTGRES_USER:$$cap_POSTGRES_PASSWORD@srv-captain--$$cap_appname-db/$$cap_POSTGRES_DB
+            NEXTAUTH_URL: http://$$cap_appname-builder.$$cap_root_domain
             NEXT_PUBLIC_VIEWER_URL: http://$$cap_appname-viewer.$$cap_root_domain
             ENCRYPTION_SECRET: $$cap_TYPEBOT_ENCRYPTION_SECRET
-            NEXTAUTH_URL: http://$$cap_appname-builder.$$cap_root_domain
+            ADMIN_EMAIL: $$cap_TYPEBOT_ADMIN_EMAIL
+            NEXTAUTH_URL_INTERNAL: http://srv-captain--$$cap_appname-builder:3000
+            DEFAULT_WORKSPACE_PLAN: $$cap_TYPEBOT_DEFAULT_WORKSPACE_PLAN
+            DISABLE_SIGNUP: $$cap_TYPEBOT_DISABLE_SIGNUP
             SMTP_USERNAME: $$cap_TYPEBOT_SMTP_USERNAME
             SMTP_PASSWORD: $$cap_TYPEBOT_SMTP_PASSWORD
             SMTP_HOST: $$cap_TYPEBOT_SMTP_HOST
             SMTP_PORT: $$cap_TYPEBOT_SMTP_PORT
-            SMTP_FROM: $$cap_TYPEBOT_SMTP_FROM
+            NEXT_PUBLIC_SMTP_FROM: $$cap_TYPEBOT_NEXT_PUBLIC_SMTP_FROM
             SMTP_SECURE: $$cap_TYPEBOT_SMTP_SECURE
-            GOOGLE_CLIENT_ID: $$cap_TYPEBOT_GOOGLE_CLIENT_ID
-            GOOGLE_CLIENT_SECRET: $$cap_TYPEBOT_GOOGLE_CLIENT_SECRET
-            S3_ACCESS_KEY: $$cap_TYPEBOT_S3_ACCESS_KEY
-            S3_SECRET_KEY: $$cap_TYPEBOT_S3_SECRET_KEY
-            S3_BUCKET: $$cap_TYPEBOT_S3_BUCKET
-            S3_PORT: $$cap_TYPEBOT_S3_PORT
-            S3_ENDPOINT: $$cap_TYPEBOT_S3_ENDPOINT
-            S3_SSL: $$cap_TYPEBOT_S3_SSL
-            S3_REGION: $$cap_TYPEBOT_S3_REGION
+            SMTP_AUTH_DISABLED: $$cap_TYPEBOT_SMTP_AUTH_DISABLED
         depends_on:
             - $$cap_appname-db
 
@@ -86,11 +62,6 @@ caproverOneClickApp:
         start: |-
             Typebot is an open-source alternative to Landbot.
             It allows you to create conversational apps/forms (Lead qualification, Product launch, User onboarding, Customer support), embed them anywhere on your web/mobile apps, and collect results in real-time.
-
-            **Important notes**:
-
-            - Make sure to set up least one authentication provider (Mail, Google, GitHub, Facebook or Azure AD) below
-            - Add your mail address to `ADMIN_EMAIL`
         end: |-
             Typebot has been successfully deployed! It might take few moments before it's fully started.
             You can access it at `http://$$cap_appname-builder.$$cap_root_domain`.
@@ -99,151 +70,76 @@ caproverOneClickApp:
     description: Conversational Form Builder That You Can Self-Host. Open Source Alternative To Landbot.
     documentation: https://docs.typebot.io
     variables:
-        - id: $$cap_TYPEBOT_VERSION
-          label: Version | Typebot
-          description: Version of Typebot. Check out their valid tags at https://hub.docker.com/r/baptistearno/typebot-builder/tags
-          defaultValue: 2
-          validRegex: /.{1,}/
         - id: $$cap_POSTGRES_VERSION
-          label: General | PostgreSQL Version
+          label: POSTGRES_VERSION
           description: Check out their valid tags at https://hub.docker.com/_/postgres/tags
           defaultValue: '14.0-alpine'
           validRegex: /.{1,}/
-        - id: $$cap_TYPEBOT_ADMIN_EMAIL
-          label: Administration | User Mail Address
-          description: The mail address that will get a "Pro" plan on user creation.
-        - id: $$cap_TYPEBOT_DISABLE_SIGNUP
-          label: Administration | Disable Sign-Ups
-          description: To disable new sign-ups but still be able to sign in with existing users or admin mail address.
-          defaultValue: 'false'
-          validRegex: /^(true|false)$/
-        - id: $$cap_TYPEBOT_ENCRYPTION_SECRET
-          label: Security | Encryption Secret
-          description: >-
-              A 256-bit key used to encrypt sensitive data.
-              The secret should be the same between builder and viewer.
-          defaultValue: $$cap_gen_random_hex(128)
-          validRegex: /.{1,}/
         - id: $$cap_POSTGRES_DB
-          label: Database | Name
+          label: POSTGRES_DB
           description: Name of the database.
           defaultValue: typebot
           validRegex: /.{1,}/
         - id: $$cap_POSTGRES_USER
-          label: Database | User Name
+          label: POSTGRES_USER
           description: Name of the database user.
           defaultValue: typebot
           validRegex: /.{1,}/
         - id: $$cap_POSTGRES_PASSWORD
-          label: Database | User Password
+          label: POSTGRES_PASSWORD
           description: Password of the database user.
           defaultValue: $$cap_gen_random_hex(16)
           validRegex: /.{1,}/
+        - id: $$cap_TYPEBOT_VERSION
+          label: TYPEBOT_VERSION
+          description: Version of Typebot. Check out their valid tags at https://hub.docker.com/r/baptistearno/typebot-builder/tags
+          defaultValue: 2.22.2
+          validRegex: /.{1,}/
+        - id: $$cap_TYPEBOT_ENCRYPTION_SECRET
+          label: ENCRYPTION_SECRET
+          description: A 256-bit key used to encrypt sensitive data. The secret should be the same between builder and viewer. You can also generate one running `openssl rand -base64 24 | tr -d '\n' ; echo`
+          defaultValue: $$cap_gen_random_hex(32)
+          validRegex: /.{1,}/
+        - id: $$cap_TYPEBOT_ADMIN_EMAIL
+          label: ADMIN_EMAIL
+          description: The email that will get an UNLIMITED plan on user creation. The associated user will be able to bypass database rules. You can provide multiple emails separated by a comma without spaces.
+          validRegex: /.{1,}/
+        - id: $$cap_TYPEBOT_DEFAULT_WORKSPACE_PLAN
+          label: DEFAULT_WORKSPACE_PLAN
+          description: Default workspace plan on user creation or when a user creates a new workspace. Possible values are FREE, STARTER, PRO, LIFETIME, UNLIMITED. The default plan for admin user is UNLIMITED.
+          defaultValue: FREE
+        - id: $$cap_TYPEBOT_DISABLE_SIGNUP
+          label: DISABLE_SIGNUP
+          description: Disable new user sign ups. Invited users are still able to sign up.
+          defaultValue: 'false'
+          validRegex: /^(true|false)$/
         - id: $$cap_TYPEBOT_SMTP_USERNAME
-          label: Mail | Name
-          description: Optional SMTP username.
+          label: SMTP_USERNAME
+          description: SMTP username.
+          validRegex: /.{1,}/
         - id: $$cap_TYPEBOT_SMTP_PASSWORD
-          label: Mail | Password
-          description: Optional SMTP password.
+          label: SMTP_PASSWORD
+          description: SMTP password.
+          validRegex: /.{1,}/
         - id: $$cap_TYPEBOT_SMTP_HOST
-          label: Mail | Host
-          description: Optional SMTP host.
+          label: SMTP_HOST
+          description: SMTP host.
+          validRegex: /.{1,}/
         - id: $$cap_TYPEBOT_SMTP_PORT
-          label: Mail | Port
+          label: SMTP_PORT
           description: SMTP port.
           defaultValue: 25
           validRegex: /.{1,}/
-        - id: $$cap_TYPEBOT_SMTP_FROM
-          label: Mail | From Field
-          description: Optional "from" name and mail (e.g. `Notifications <notifications@example.com>`).
+        - id: $$cap_TYPEBOT_NEXT_PUBLIC_SMTP_FROM
+          label: NEXT_PUBLIC_SMTP_FROM
+          description: From name and email (i.e. `Typebot Notifications <notifications@host.com>`)
         - id: $$cap_TYPEBOT_SMTP_SECURE
-          label: Mail | Secure Connection
-          description: >-
-              If `true` the connection will use TLS when connecting to server.
-              If `false` (the default) then TLS is used if server supports the STARTTLS extension.
-              In most cases set this value to `true` if you are connecting to port `465`.
-              For port `587` or `25` keep it `false`.
+          label: SMTP_SECURE
+          description: If "true" the connection will use TLS when connecting to server. If "false" (the default) then TLS is used if server supports the STARTTLS extension. In most cases set this "value" to true if you are connecting to port 465. For port 587 or 25 keep it "false".
           defaultValue: 'false'
           validRegex: /^(true|false)$/
         - id: $$cap_TYPEBOT_SMTP_AUTH_DISABLED
-          label: Mail | Authentication Disabled
-          description: To disable the authentication by mail but still use the provided config for notifications.
+          label: SMTP_AUTH_DISABLED
+          description: To disable the authentication by email but still use the provided config for notifications.
           defaultValue: 'false'
           validRegex: /^(true|false)$/
-        - id: $$cap_TYPEBOT_GOOGLE_CLIENT_ID
-          label: Google | Client ID
-          description: Optional client ID from the Google API Console.
-        - id: $$cap_TYPEBOT_GOOGLE_CLIENT_SECRET
-          label: Google | Client Secret
-          description: Optional client secret from the Google API Console.
-        - id: $$cap_TYPEBOT_GOOGLE_API_KEY
-          label: Google | API Key
-          description: Optional API Key from the Google API Console. Used for Google Fonts.
-        - id: $$cap_TYPEBOT_GITHUB_CLIENT_ID
-          label: GitHub | Client ID
-          description: Optional application client ID from GitHub. Also used to check if it is enabled in the front-end.
-        - id: $$cap_TYPEBOT_GITHUB_CLIENT_SECRET
-          label: GitHub | Client Secret
-          description: Optional application secret from GitHub.
-        - id: $$cap_TYPEBOT_GITLAB_CLIENT_ID
-          label: GitLab | Client ID
-          description: Optional application client ID from GitLab. Also used to check if it is enabled in the front-end.
-        - id: $$cap_TYPEBOT_GITLAB_CLIENT_SECRET
-          label: GitLab | Client Secret
-          description: Optional application secret from GitLab.
-        - id: $$cap_TYPEBOT_GITLAB_BASE_URL
-          label: GitLab | Base URL
-          description: Optional GitLab instance base URL.
-          defaultValue: https://gitlab.com
-          validRegex: /.{1,}/
-        - id: $$cap_TYPEBOT_GITLAB_REQUIRED_GROUPS
-          label: GitLab | Required Groups
-          description: Optional comma-separated list of groups the user has to be a direct member of (e.g. `foo,bar`).
-        - id: $$cap_TYPEBOT_GITLAB_NAME
-          label: GitLab | Base URL
-          description: Name of the GitLab instance, used for the SSO Login Button.
-          defaultValue: GitLab
-          validRegex: /.{1,}/
-        - id: $$cap_TYPEBOT_FACEBOOK_CLIENT_ID
-          label: Facebook | Client ID
-          description: Optional application client ID from Facebook. Also used to check if it is enabled in the front-end.
-        - id: $$cap_TYPEBOT_FACEBOOK_CLIENT_SECRET
-          label: Facebook | Client Secret
-          description: Optional application secret from Facebook.
-        - id: $$cap_TYPEBOT_AZURE_AD_CLIENT_ID
-          label: Azure AD | Client ID
-          description: Optional application client ID from Azure AD. Also used to check if it is enabled in the front-end.
-        - id: $$cap_TYPEBOT_AZURE_AD_CLIENT_SECRET
-          label: Azure AD | Client Secret
-          description: Optional application client secret from Azure AD. Can be obtained from Azure Portal.
-        - id: $$cap_TYPEBOT_AZURE_AD_TENANT_ID
-          label: Azure AD | Tenant ID
-          description: Optional Azure AD tenant ID.
-        - id: $$cap_TYPEBOT_S3_ACCESS_KEY
-          label: S3 | Access Key
-          description: Optional S3 access key. Also used to check if upload feature is enabled.
-        - id: $$cap_TYPEBOT_S3_SECRET_KEY
-          label: S3 | Secret Key
-          description: Optional S3 secret key.
-        - id: $$cap_TYPEBOT_S3_BUCKET
-          label: S3 | Bucket
-          description: Name of the bucket where assets will be uploaded in.
-          defaultValue: typebot
-          validRegex: /.{1,}/
-        - id: $$cap_TYPEBOT_S3_PORT
-          label: S3 | Port
-          description: Optional S3 host port number.
-        - id: $$cap_TYPEBOT_S3_ENDPOINT
-          label: S3 | Endpoint
-          description: Optional S3 endpoint.
-        - id: $$cap_TYPEBOT_S3_SSL
-          label: S3 | Secure Connection
-          description: Whether to use SSL when establishing the connection.
-          defaultValue: 'true'
-          validRegex: /^(true|false)$/
-        - id: $$cap_TYPEBOT_S3_REGION
-          label: S3 | Region
-          description: Optional S3 region.
-        - id: $$cap_TYPEBOT_GIPHY_API_KEY
-          label: Giphy | API Key
-          description: Optional Giphy API key.


### PR DESCRIPTION
This pull request updates Typebot to version 2.22.2 and simplifies the setup.

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
