### PR TITLE
Bumped node-red version to current 3.1.8

### DIFF
--- a/public/v4/apps/node-red.yml
+++ b/public/v4/apps/node-red.yml
@@ -14,19 +14,21 @@ caproverOneClickApp:
         - id: $$cap_node-red_version
           label: node-red version tag
           description: Check out their docker page for the valid tags @ https://hub.docker.com/r/nodered/node-red/tags
-          defaultValue: 1.1.3-12-minimal
+          defaultValue: 3.1.8-18-minimal
         - id: $$cap_node-red_timezone
-          label: timezone
+          label: Time Zone
           description: Check out this list and use tz database name as value @ https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
           defaultValue: Europe/Berlin
     instructions:
         start: Low-code programming for event-driven applications
-        end: >-
-            node-red is deployed and available as $$cap_appname.
-            To make it function correctly, you have to enable websocket-support.
-            It would be also a good idea to set basic authentication or modify the node-red settings respectively to the documentation.
+        end: |-
+            `node-red` has been successfully deployed and is now available at http://$$cap_appname.$$cap_root_domain!
 
-            IMPORTANT: It will take up to 2 minutes for node-red to be ready. Before that, you might see 502 error page.
+            **REQUIRED**: Enable websocket-support in `HTTP Settings`.
+
+            It is recommended that you setup basic authentication and review the default settings as necessary. See the documentation at https://nodered.org/docs for more information.
+
+            IMPORTANT: It will take up to 2 minutes for `node-red` to be ready. Before that, you might see 502 error page.
     displayName: 'Node-Red'
     description: Low-code programming for event-driven applications
     documentation: Read the documentation @ https://nodered.org/docs/


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [X] I have tested the template using the method described in README.md thoroughly
- [X] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [X] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [X] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [X] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).

---

This is primarily a basic version bump to the current release image tagged `3.1.8-18-minimal`. I have it running on two app servers, both running Caprover on Debian, no issues. I also tweaked the instructions for clarity, but made no substantial changes to the content.

Thanks to @githubsaturn for all your efforts!