### PR TITLE
Update Immich to v1.105.1

### DIFF
--- a/public/v4/apps/immich.yml
+++ b/public/v4/apps/immich.yml
@@ -81,14 +81,14 @@ caproverOneClickApp:
     documentation: https://immich.app
     instructions:
         start: |-
-            Leave every default value as is for a working and simple installation. You can specify the (full) path to the directory you want to save your media, in that case the directory must exist beforehand. Immich can be accessed via browser and with an app (Immich). If you have big media files (bigger than 500MB) in your phone, update your Nginx configuration to increase your `client_max_body_size`.
+            Leave every default value as is for a working and simple installation. You can specify the (full) path to the directory you want to save your media at. The directory must exist beforehand. Immich can be used from a browser but kind of requires you to install the Immich app on your phone. If you have big media files (bigger than 500MB) that you want to backup, update your Nginx configuration file in caprover to increase your `client_max_body_size`.
         end: |-
-            On your first visit it will ask for email and password for the admin user. Remember to change the default Nginx configuration and increasing the 'client_max_body_size' value if you expect to upload files bigger than 500MB.
+            On your first visit it will ask for email and password to set up the admin user. Remember to change the default Nginx configuration and increasing the 'client_max_body_size' value if you expect to backup files bigger than 500MB. They will fail to upload if you don't.
     variables:
         - label: Immich version
           id: $$cap_version
           description: Check out their valid tags at https://github.com/immich-app/immich/releases
-          defaultValue: v1.99.0
+          defaultValue: v1.105.1
         - label: Immich redis version
           id: $$cap_redis_ver
           defaultValue: 6.2-alpine@sha256:c5a607fb6e1bb15d32bbcf14db22787d19e428d59e31a5da67511b49bb0f1ccc


### PR DESCRIPTION
Minor update to v1.105.1 to keep up with changes in the mobile app version. I also used the update to mildy rewrite the instructions for (hopefully) improved clarity.

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
