### PR TITLE
Create captain-definition for caprover/one-click-apps

### DIFF
--- a/captain-definition
+++ b/captain-definition
@@ -1,7 +1,7 @@
 {
     "schemaVersion": 2,
     "dockerfileLines": [
-        "FROM node as build",
+        "FROM node:22.2.0-bookworm as build",
         "COPY . /app",
         "WORKDIR /app",
         "RUN npm i",

--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,12 @@
+{
+    "schemaVersion": 2,
+    "dockerfileLines": [
+        "FROM node as build",
+        "COPY . /app",
+        "WORKDIR /app",
+        "RUN npm i",
+        "RUN npm run build",
+        "FROM nginx:mainline-alpine-slim",
+        "COPY --from=build /app/dist /usr/share/nginx/html"
+    ]
+}


### PR DESCRIPTION
I have tested this deploying from https://git.aly.pet/aly/caprover-apps to https://caprover-apps.aly.pet/. I plan to add an index page to this third party repo, or add a markdown renderer for README.md, but that's out of scope for this particular pull request and could be added to this repository at a later date. My hope is to make it easier for other users to create third party repositories for CapRover hosted on their own infrastructure.


### ☑️ Self Check before Merge

- [x] I will take responsibility addressing any issues that arise as a result of this PR (maintaining this file).
- ~~I have tested the template using the method described in README.md thoroughly~~
- ~~I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.~~
- ~~I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.~~
- ~~I have made sure that instructions.start and instructions.end are clear and self-explanatory.~~
- ~~Icon is added as a png file to the logos directory.~~
- ~~I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)~~
