### PR TITLE
Updates Immich to version 1.106.4 (latest)

### DIFF
--- a/public/v4/apps/immich.yml
+++ b/public/v4/apps/immich.yml
@@ -22,27 +22,6 @@ services:
             - $$cap_appname-redis
             - $$cap_appname-db
 
-    $$cap_appname-microservices:
-        caproverExtra:
-            notExposeAsWebApp: 'true'
-            dockerfileLines:
-                - FROM ghcr.io/immich-app/immich-server:$$cap_version
-                - CMD ["start.sh", "microservices"]
-        environment:
-            DB_PASSWORD: $$cap_app_db_pass
-            DB_USERNAME: $$cap_app_db_user
-            DB_DATABASE_NAME: $$cap_app_db_name
-            DB_HOSTNAME: srv-captain--$$cap_appname-db
-            REDIS_HOSTNAME: srv-captain--$$cap_appname-redis
-            UPLOAD_LOCATION: $$cap_app_upload_location
-            IMMICH_MACHINE_LEARNING_URL: http://srv-captain--$$cap_appname-machine-learning:3003
-        volumes:
-            - $$cap_app_upload_location:/usr/src/app/upload
-            - /etc/localtime:/etc/localtime:ro
-        depends_on:
-            - $$cap_appname-redis
-            - $$cap_appname-db
-
     $$cap_appname-machine-learning:
         caproverExtra:
             notExposeAsWebApp: 'true'
@@ -88,7 +67,7 @@ caproverOneClickApp:
         - label: Immich version
           id: $$cap_version
           description: Check out their valid tags at https://github.com/immich-app/immich/releases
-          defaultValue: v1.105.1
+          defaultValue: v1.106.4
         - label: Immich redis version
           id: $$cap_redis_ver
           defaultValue: 6.2-alpine@sha256:c5a607fb6e1bb15d32bbcf14db22787d19e428d59e31a5da67511b49bb0f1ccc


### PR DESCRIPTION
The latest immich release removes the need for the `immich-microservices` container (the `immich-server` one will provide the functionality by default).

The most recent mobile app won't work without updating the server to this version.

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
