### PR TITLE
fix: Container HTTP port for Open SpeedTest

### DIFF
--- a/public/v4/apps/openspeedtest.yml
+++ b/public/v4/apps/openspeedtest.yml
@@ -4,7 +4,7 @@ services:
     '$$cap_appname':
         image: index.docker.io/openspeedtest/latest:$$cap_openspeedtest_version
         caproverExtra:
-            containerHttpPort: '3001'
+            containerHttpPort: '3000'
         restart: always
 
 caproverOneClickApp:


### PR DESCRIPTION
Fixing default container HTTP port for Open SeedTest.

Current default (3001) shows a NGINX https over http port error page.