### PR TITLE
Update sshd app's image to the version-9.7_p1-r4

### DIFF
--- a/public/v4/apps/sshd.yml
+++ b/public/v4/apps/sshd.yml
@@ -1,7 +1,7 @@
 captainVersion: 4
 services:
     $$cap_appname:
-        image: lscr.io/linuxserver/openssh-server:version-8.6_p1-r3
+        image: lscr.io/linuxserver/openssh-server:version-9.7_p1-r4
         environment:
             PUID: 1001
             PGID: 1001


### PR DESCRIPTION
The current version of `sshd.yml` contains very old base image for openssh-server (`lscr.io/linuxserver/openssh-server:version-8.6_p1-r3`).
However, SSH tunnel mod (`linuxserver/mods:openssh-server-ssh-tunnel`) is already ported to the s6 v3 (https://github.com/linuxserver/docker-mods/tree/master?tab=readme-ov-file#new-v3-mods) and the base image doesn't work properly with the updated mod.
More specifically mod does not modify the `sshd_config` file to make SSH tunnel work, hence manual modification of configuration was required.
This should fix the issue https://github.com/caprover/one-click-apps/issues/1041


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
