### PR TITLE
Mautic v5 Update - Always clear cache in Service Update Override

### DIFF
--- a/public/v4/apps/mautic.yml
+++ b/public/v4/apps/mautic.yml
@@ -86,7 +86,7 @@ caproverOneClickApp:
             b. In "Environmental Variables", ensure these variables are set correctly:
                 - APACHE_SERVER_NAME = $$cap_appname.$$cap_root_domain
             c. Find the "Service Update Override" section.
-            d. Copy and paste this script:
+            d. Copy and paste this script (which sets apache server name, turns on https, and clears mautic cache every startup for smoother running):
                 ```
                 TaskTemplate:
                     ContainerSpec:
@@ -96,6 +96,7 @@ caproverOneClickApp:
                         - |
                             echo "ServerName ${APACHE_SERVER_NAME}" >> /etc/apache2/apache2.conf
                             echo "SetEnvIf X-Forwarded-Proto https HTTPS=on" >> /etc/apache2/apache2.conf
+                            rm -rf /var/www/html/var/cache/*
                             apache2-foreground
                 ```
             e. Click "Save & Update" at the bottom of the page.


### PR DESCRIPTION
I've noticed when rebooting Caprover server or restarting app, mautic wants the cache cleared - adding to startup script.

Mautic will show a most annoying message

 "The site is currently offline due to encountering an error. If the problem persists, please contact the system administrator"

And nothing else. in Mautic forums, everybody suggests just to clear the cache.

This update just does that every time, as there really is no negatives, you've restarted the server anyway, what's another few seconds to get loaded up.

https://forum.mautic.org/t/the-site-is-currently-offline-due-to-encountering-an-error-if-the-problem-persists-please-contact-the-system-administrator/24199/1

### ☑️ Self Check before Merge

- ☑️ I have tested the template using the method described in README.md thoroughly
- ☑️ I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- ☑️ I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- ☑️ I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- ☑️ Icon is added as a png file to the logos directory.
- ☑️ I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
-☑️ I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
