### PR TITLE
Fixed MAIL_DRIVER default option for Docmost app

### DIFF
--- a/public/v4/apps/docmost.yml
+++ b/public/v4/apps/docmost.yml
@@ -91,7 +91,8 @@ caproverOneClickApp:
         - description: The endpoint URL for your S3 service (optional).
           id: $$cap_aws_s3_endpoint
           label: '[OPTIONAL] S3 service endpoint URL'
-        - description: The mail driver to use for sending emails, can be "smtp" or "postmark".
+        - defaultValue: smtp
+          description: The mail driver to use for sending emails, can be "smtp" or "postmark".
           id: $$cap_mail_driver
           label: '[OPTIONAL] Mail driver'
         - description: The token for Postmark, if using Postmark as the mail driver.


### PR DESCRIPTION
Hi,

I'm really sorry about the issue with my previous pull request. I didn't mean for that to happen, and this new PR fix the problem. I've corrected the default MAIL_DRIVER option for the Docmost app, which was causing the app to crash in a loop on startup without this environment variable set.

I tested everything from scratch, and it's all working fine now.

Apologies again for the trouble, and thanks for your understanding. 🙇‍♀️