### PR TITLE
Update keycloak.yml

### DIFF
--- a/public/v4/apps/keycloak.yml
+++ b/public/v4/apps/keycloak.yml
@@ -16,8 +16,8 @@ services:
             - $$cap_appname-db
         restart: always
         environment:
-            KEYCLOAK_ADMIN: $$cap_keycloak_admin
-            KEYCLOAK_ADMIN_PASSWORD: $$cap_keycloak_password
+            KC_BOOTSTRAP_ADMIN_USERNAME: $$cap_keycloak_admin
+            KC_BOOTSTRAP_ADMIN_PASSWORD: $$cap_keycloak_password
             KC_DB_PASSWORD: $$cap_pg_pass
         caproverExtra:
             containerHttpPort: '8080'
@@ -36,19 +36,19 @@ services:
                 - ENV KC_DB_USERNAME=keycloak
                 - ENV KC_DB_PASSWORD=$$cap_pg_pass
                 - ENV KC_HOSTNAME=$$cap_appname.$$cap_root_domain
-                - ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start", "--optimized", "--proxy=edge"]
+                - ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start", "--optimized",  "--proxy-headers=xforwarded", "--http-enabled=true"]
 
 caproverOneClickApp:
     variables:
         - id: $$cap_postgres_version
           label: Postgres Version
-          defaultValue: '15'
+          defaultValue: '16'
           description: Check out Keycloak DB page for any valid major tested https://www.keycloak.org/server/db
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_keycloak_version
           label: Keycloak Version
-          defaultValue: '23.0.1'
-          description: v23.0.1 current as of 2023-12-06.  Check out Keycloak Docker page for the valid tags https://quay.io/repository/keycloak/keycloak?tab=tags
+          defaultValue: '26.0.2'
+          description: v26.0.2 current as of 2024-10-24.  Check out Keycloak Docker page for the valid tags https://quay.io/repository/keycloak/keycloak?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_pg_pass
           label: Postgres Password


### PR DESCRIPTION
Newest version 26.0.2
Postgres version 16

--proxy was deprecated
---proxy-headers=xforwarded is necessary
and for replacement of --proxy=edge also --http-enabled=true

ENV variables were changed, too.

https://www.keycloak.org/docs/latest/upgrading/index.html#deprecated-proxy-option

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
