### PR TITLE
[windmill] Version bumps and rename webserver service

### DIFF
--- a/public/v4/apps/windmill.yml
+++ b/public/v4/apps/windmill.yml
@@ -89,12 +89,12 @@ caproverOneClickApp:
     variables:
         - id: $$cap_app_version
           label: Windmill Version
-          defaultValue: '1.219.1'
+          defaultValue: '1.434.1'
           description: Checkout their github page for the valid tags https://github.com/windmill-labs/windmill/releases
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_postgres_version
           label: Postgres Version
-          defaultValue: '15-alpine'
+          defaultValue: '16-alpine'
           description: Checkout their page for the valid tags https://hub.docker.com/_/postgres
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_postgres_pass

--- a/public/v4/apps/windmill.yml
+++ b/public/v4/apps/windmill.yml
@@ -12,7 +12,7 @@ services:
         caproverExtra:
             notExposeAsWebApp: 'true'
 
-    $$cap_appname-server:
+    $$cap_appname:
         image: ghcr.io/windmill-labs/windmill:$$cap_app_version
         expose:
             - 8000


### PR DESCRIPTION
### What I changed

- Bump versions for windmill and for its postgres database
- rename `windmill-server` to `windmill` (or whatever `$$cap_appname` is`): This new name is what the `instructions.end` already uses, so this PR fixes the minor bug.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
