### PR TITLE
Update mysql.yml

### DIFF
--- a/public/v4/apps/mysql.yml
+++ b/public/v4/apps/mysql.yml
@@ -13,7 +13,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_mysql_version
           label: MySQL Version
-          defaultValue: '5.7'
+          defaultValue: '8.4.3'
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/library/mysql/tags/
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_db_pass


### PR DESCRIPTION
Upgrade MySQL from EOL version 5.7 to latest LTSR

MySQL 5.7 reached End of Life in October 2023 (see https://en.wikipedia.org/wiki/MySQL). Upgrade to the latest supported LTSR version to ensure continued security updates, compatibility, and stability.

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly

