### PR TITLE
Update wordpress.yml

### DIFF
--- a/public/v4/apps/wordpress.yml
+++ b/public/v4/apps/wordpress.yml
@@ -36,7 +36,7 @@ caproverOneClickApp:
           defaultValue: $$cap_gen_random_hex(16)
         - id: $$cap_wp_version
           label: WordPress Version
-          defaultValue: '6.0.1'
+          defaultValue: '6.7.1'
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/library/wordpress/tags/
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_db_type
@@ -46,7 +46,7 @@ caproverOneClickApp:
           validRegex: /^(mysql|mariadb)$/
         - id: $$cap_database_version
           label: Database Version, default is MySQL
-          defaultValue: '8.0.29'
+          defaultValue: '8.4.3'
           description: Check out the Docker pages for the valid tags https://hub.docker.com/r/library/mysql/tags/ or https://hub.docker.com/_/mariadb?tab=tags
           validRegex: /^([^\s^\/])+$/
     instructions:


### PR DESCRIPTION
Update WordPress to 6.7 and upgrade MySQL to latest LTS version 8.4.3

Refer to https://make.wordpress.org/hosting/2024/11/05/wordpress-6-7-server-compatibility/ for server compatibility details.

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
