### PR TITLE
Fix docker hub url for valkey

### DIFF
--- a/public/v4/apps/valkey.yml
+++ b/public/v4/apps/valkey.yml
@@ -13,7 +13,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_valkey_version
           label: Valkey Version Tag
-          description: 'Check out their Docker page for the valid tags: https://hub.docker.com/valkey/valkey?tab=tags'
+          description: 'Check out their Docker page for the valid tags: https://hub.docker.com/r/valkey/valkey/tags'
           defaultValue: '8.0.1-alpine'
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_valkey_extra_flags
@@ -32,4 +32,4 @@ caproverOneClickApp:
     displayName: 'Valkey'
     isOfficial: true
     description: Valkey is a flexible distributed key-value datastore that supports both caching and beyond caching workloads.
-    documentation: Taken from https://hub.docker.com/valkey/valkey
+    documentation: Taken from https://hub.docker.com/r/valkey/valkey


### PR DESCRIPTION
Noticed that the docker hub url for valkey was leading to a 404 page, so I fixed it.

I looked for others, and this seems to be the only app not having either `/r` or `/_`.

<hr>

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly