### PR TITLE
Fix n8n persistant dir

### DIFF
--- a/public/v4/apps/n8n-io.yml
+++ b/public/v4/apps/n8n-io.yml
@@ -37,7 +37,7 @@ services:
             WEBHOOK_URL: https://$$cap_appname.$$cap_root_domain
             N8N_EDITOR_BASE_URL: https://$$cap_appname.$$cap_root_domain
         volumes:
-            - $$cap_appname:/root/.n8n
+            - $$cap_appname:/home/node/.n8n
             - $$cap_appname-files:/files
         depends_on:
             - $$cap_appname-db


### PR DESCRIPTION
This fixes the persistant directory, which is wrong initially

This is especially anoying because if you fix the path after having used n8n for a while it messes up the ecryption key of all your services (credentials, apis etc) which resets all your integrations