### PR TITLE
Prefer "command" over dockerfileLines for one-click-app customizations

### DIFF
--- a/public/v4/apps/filebrowser.yml
+++ b/public/v4/apps/filebrowser.yml
@@ -6,13 +6,9 @@ services:
             - $$cap_appname-files:/srv
         restart: always
         environment: {}
-        caproverExtra:
-            dockerfileLines:
-                - FROM alpine:latest as helper
-                - '# Similar to the original file, except, /database.db is inside a directory now so that we can assign a volume to it.'
-                - RUN echo "{'port':80,'baseURL':'','address':'','log':'stdout','database':'/database/database.db','root':'/srv'}" | sed "s/\'/\"/g" >/.edited.json
-                - FROM filebrowser/filebrowser:$$cap_filebrowser_version
-                - COPY --from=helper /.edited.json /.filebrowser.json
+        # Point filebrowser to our volume mounts for database and files root:
+        command: ['/filebrowser', '-d', '/database/database.db', '-r', '/srv']
+        image: filebrowser/filebrowser:$$cap_filebrowser_version
 caproverOneClickApp:
     variables:
         - id: $$cap_filebrowser_version

--- a/public/v4/apps/redis.yml
+++ b/public/v4/apps/redis.yml
@@ -6,10 +6,9 @@ services:
         restart: always
         environment:
             REDIS_PASSWORD: $$cap_redis_password
+        image: redis:$$cap_redis_version
+        command: ['sh', '-c', 'redis-server --requirepass $REDIS_PASSWORD']
         caproverExtra:
-            dockerfileLines:
-                - FROM redis:$$cap_redis_version
-                - CMD exec redis-server --requirepass "$REDIS_PASSWORD"
             notExposeAsWebApp: 'true'
 caproverOneClickApp:
     variables:


### PR DESCRIPTION
Maintain one-click-app customizations across subsequent deployments.


### Motivation

There are times you need to change some of the configuration inside the upstream Docker image.  We have found that it's best practice to use Service Update Override (instead of alternatives like using `dockerfileLines` to build a derivative image with overridden configuration).

I acknowledge that there are types of customization when `dockerfileLines` is needed (such as to disable a `HEALTHCHECK` defined in the Dockerfile on a worker service), but these end up being extremely rare.

#### Persistence of config
Service Update Override persists when a new image is deployed (for example, you want to bump the app software version through "Deploy via ImageName").

#### Better Transparency
The modifications to app config can always be viewed in the CapRover UI, under `App Configs > Service Update Override`:
> ![image](https://github.com/user-attachments/assets/ccb343d0-5bc1-470a-9cf8-0bb8cf850f09)

Also the version of the currently deployed app can always be viewed in the CapRover UI, under `Deployment > Version History`:
> ![Screenshot from 2025-02-25 10-13-30](https://github.com/user-attachments/assets/e01f2316-7c84-420d-a39b-5d8843299136)

By contrast, when the one-click app was used `dockerfileLines` to specify both the version and customizations,
- the CapRover admin user cannot view the customizations anywhere after installation.
- the CapRover admin user cannot view the current app version deployed.
- the CapRover admin user cannot easily bump to a new app Docker version; he needs to re-create the entire custom `dockerfileLines` from scratch.


### What I changed

1. Switch **redis** one-click app to use docker-compose `command:` & `image:` instead of `caproverExtra.dockerfileLines`.
    - To verify this works, I installed the new one-click app and successfully connected to it from another container.
    - To verify the value-add of this PR, I successfully upgraded my installed redis app to a newer version of redis simply by using `"Deploy via ImageName": redis:7.4.2`; the configuration (password and data volume) are maintained across this upgrade without me needing to know about them.



2. Switch **filebrowser** one-click app to use docker-compose `command:` & `image:`  to set the database and files root, instead of `caproverExtra.dockerfileLines`.
    - To verify this works, I installed the new one-click app, and viewed files on a Docker-managed volume and also on a localhost volume mount.

Another unexpected upshot of these changes is also that the one-click app YAML is also now more straightforward: closer to a traditional docker-compose.yml.




### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [ ] **out of scope** I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [ ] **out of scope** I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] **out of scope** Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
