### PR TITLE
update Docker image to official evolutionapi channel

### DIFF
--- a/public/v4/apps/evolution-api.yml
+++ b/public/v4/apps/evolution-api.yml
@@ -204,7 +204,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_ant_version
           label: Evolution API Version
-          description: Choose the latest version of Evolution API from https://hub.docker.com/r/atendai/evolution-api/tags
+          description: Choose the latest version of Evolution API from https://hub.docker.com/r/evoapicloud/evolution-api/tags
           defaultValue: v2.2.1
         - id: $$cap_postgres_version
           label: PostgreSQL Version


### PR DESCRIPTION
Switched Docker image source to the official evolutionapi channel on Docker Hub.
This ensures alignment with the maintained and verified version of the API image.

Previous source: atendai/evolution-api
New source: evoapicloud/evolution-api

### ☑️ Self Check before Merge

- [☑️] I have tested the template using the method described in README.md thoroughly
- [☑️] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [☑️] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [☑️] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [☑️] Icon is added as a png file to the logos directory.
- [☑️] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [☑️] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
