### PR TITLE
Upgrade default version of Bugsink to 1.7.4

### DIFF
--- a/public/v4/apps/bugsink.yml
+++ b/public/v4/apps/bugsink.yml
@@ -52,7 +52,7 @@ caproverOneClickApp:
     variables:
         - id: '$$cap_BUGSINK_VERSION'
           label: Bugsink Version
-          defaultValue: '1.4.2'
+          defaultValue: '1.7.4'
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/bugsink/bugsink/tags
           validRegex: '/.{1,}/'
         - id: $$cap_MYSQL_VERSION


### PR DESCRIPTION
direct cause: https://www.bugsink.com/blog/path-traversal-via-event-id-in-ingestion/
