### PR TITLE
feat: switch from single-arch digest to multi-arch tag for prometheus

### DIFF
--- a/public/v4/apps/prometheus.yml
+++ b/public/v4/apps/prometheus.yml
@@ -1,23 +1,33 @@
 captainVersion: 4
 services:
-    $$cap_appname:
-        image: prom/prometheus@$$cap_version
-        restart: always
-        volumes:
-            - $$cap_appname-config:/etc/prometheus
-            - $$cap_appname-data:/prometheus
-        caproverExtra:
-            containerHttpPort: '9090'
+  $$cap_appname:
+    image: $$cap_image_repo:$$cap_version
+    volumes:
+      - $$cap_appname-config:/etc/prometheus
+      - $$cap_appname-data:/prometheus
+    caproverExtra:
+      containerHttpPort: '9090'
+
 caproverOneClickApp:
-    variables:
-        - label: Prometheus Docker Hash
-          defaultValue: sha256:43b19072ef98fd0ea5a29ac794fbadf365cca6d5247830034c7b86ae9650126c
-          description: Starts with 'sha256:'.  Find on Docker Hub.  Default is latest as of 2020-06-30.
-          id: $$cap_version
-    instructions:
-        end: Prometheus is now starting.
-        start: 'Read more about Prometheus: https://prometheus.io/'
-    displayName: Prometheus
-    isOfficial: true
-    description: Prometheus is a systems and service monitoring system.
-    documentation: https://hub.docker.com/r/prom/prometheus/
+  variables:
+    - id: '$$cap_image_repo'
+      label: Image repository
+      defaultValue: 'prom/prometheus'
+      description: |
+        Default official multi-arch image. For 32-bit ARM, you may use prom/prometheus-linux-armv7.
+      validRegex: '/^[a-z0-9._\\/\\-]+$/i'
+    - id: '$$cap_version'
+      label: Prometheus Docker tag
+      defaultValue: 'v3.5.0'
+      description: |
+        Use a concrete tag, not "latest". v3.5.0 is an LTS release. See release notes and tags.
+      validRegex: /^v?\d+\.\d+\.\d+.*$/
+  instructions:
+    start: |-
+      This installs Prometheus. Data is stored in a persistent volume at /prometheus.
+    end: |-
+      Prometheus is deployed at http://$$cap_appname.$$cap_root_domain
+  displayName: Prometheus
+  isOfficial: true
+  description: Systems and service monitoring
+  documentation: https://prometheus.io/docs/prometheus/latest/installation/

--- a/public/v4/apps/prometheus.yml
+++ b/public/v4/apps/prometheus.yml
@@ -1,33 +1,33 @@
 captainVersion: 4
 services:
-  $$cap_appname:
-    image: $$cap_image_repo:$$cap_version
-    volumes:
-      - $$cap_appname-config:/etc/prometheus
-      - $$cap_appname-data:/prometheus
-    caproverExtra:
-      containerHttpPort: '9090'
+    $$cap_appname:
+        image: $$cap_image_repo:$$cap_version
+        volumes:
+            - $$cap_appname-config:/etc/prometheus
+            - $$cap_appname-data:/prometheus
+        caproverExtra:
+            containerHttpPort: '9090'
 
 caproverOneClickApp:
-  variables:
-    - id: '$$cap_image_repo'
-      label: Image repository
-      defaultValue: 'prom/prometheus'
-      description: |
-        Default official multi-arch image. For 32-bit ARM, you may use prom/prometheus-linux-armv7.
-      validRegex: '/^[a-z0-9._\\/\\-]+$/i'
-    - id: '$$cap_version'
-      label: Prometheus Docker tag
-      defaultValue: 'v3.5.0'
-      description: |
-        Use a concrete tag, not "latest". v3.5.0 is an LTS release. See release notes and tags.
-      validRegex: /^v?\d+\.\d+\.\d+.*$/
-  instructions:
-    start: |-
-      This installs Prometheus. Data is stored in a persistent volume at /prometheus.
-    end: |-
-      Prometheus is deployed at http://$$cap_appname.$$cap_root_domain
-  displayName: Prometheus
-  isOfficial: true
-  description: Systems and service monitoring
-  documentation: https://prometheus.io/docs/prometheus/latest/installation/
+    variables:
+        - id: '$$cap_image_repo'
+          label: Image repository
+          defaultValue: 'prom/prometheus'
+          description: |
+              Default official multi-arch image. For 32-bit ARM, you may use prom/prometheus-linux-armv7.
+          validRegex: '/^[a-z0-9._\\/\\-]+$/i'
+        - id: '$$cap_version'
+          label: Prometheus Docker tag
+          defaultValue: 'v3.5.0'
+          description: |
+              Use a concrete tag, not "latest". v3.5.0 is an LTS release. See release notes and tags.
+          validRegex: /^v?\d+\.\d+\.\d+.*$/
+    instructions:
+        start: |-
+            This installs Prometheus. Data is stored in a persistent volume at /prometheus.
+        end: |-
+            Prometheus is deployed at http://$$cap_appname.$$cap_root_domain
+    displayName: Prometheus
+    isOfficial: true
+    description: Systems and service monitoring
+    documentation: https://prometheus.io/docs/prometheus/latest/installation/


### PR DESCRIPTION
This pr switches from single-arch digest to multi-arch tag, default v3.5.0 LTS. I was running on arm 64 vps and that digest does not work.

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).