### PR TITLE
Add DISABLE_HEALTHCHECK option to allow skipping rcon-cli health check on container startup

### DIFF
--- a/public/v4/apps/forge_minecraft.yml
+++ b/public/v4/apps/forge_minecraft.yml
@@ -16,6 +16,7 @@ services:
             RCON_PASSWORD: '$$cap_rcon_password'
             CF_API_KEY: '$$cap_cf_api_key'
             CF_PAGE_URL: '$$cap_cf_page_url'
+            DISABLE_HEALTHCHECK: '$$cap_disable_healthcheck'
         ports:
             - '$$cap_mc_port:25565'
         volumes:
@@ -99,6 +100,10 @@ caproverOneClickApp:
           label: Max no of players
           defaultValue: 20
           validRegex: /.{1,}/
+        - id: $$cap_disable_healthcheck
+          label: disable healthcheck (set TRUE if minecraft server stopping with rcon-cli)
+          defaultValue: 'FALSE'
+          validRegex: /^(TRUE|FALSE)$/
     instructions:
         start: Minecraft server with dynamic server types and modpack support. This is oneclickapp in the any of itzg's Minecraft server version.
         end: Minecraft is deployed and available as srv-captain--$$cap_appname. Note that the application may take up to ten minutes to become available.


### PR DESCRIPTION
Added an optional DISABLE_HEALTHCHECK environment variable.
When set to true, it disables the rcon-cli health check on container startup.
Useful when the server takes extra time to initialize, preventing false failures and premature container stops.

Default behavior remains unchanged.


### ☑️ Self Check before Merge

- ☑️ I have tested the template using the method described in README.md thoroughly
- ☑️ I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- ☑️ I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- ☑️ I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- ☑️ Icon is added as a png file to the logos directory.
- ☑️ I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- ☑️ I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
