### PR TITLE
Enable SSL for Hedgedoc configuration

### DIFF
--- a/public/v4/apps/hedgedoc.yml
+++ b/public/v4/apps/hedgedoc.yml
@@ -9,6 +9,7 @@ services:
             CMD_DOMAIN: $$cap_appname.$$cap_root_domain
             CMD_URL_ADDPORT: false
             PLUGIN_INSTALLER: $$cap_plugin_installer
+            CMD_PROTOCOL_USESSL: true
         volumes:
             - '$$cap_appname-uploads:/hedgedoc/public/uploads'
         caproverExtra:


### PR DESCRIPTION
I used the one-click-app to install this application in my caprover instance. I immediately enabled https and websockets as i prefer https and assumed the app used websockets. 

However i was unable to register a user out of the box as the app was intended to do. Upon investigating the dev tools in chrome, it was complaining about http request to /register being blocked. 

I was unable to register a user upon first installation until i updated the env variable to use ssl. 

`CMD_PROTOCOL_USESSL`

I'm slightly conflicted, as i suppose someone might not want to use https. If that is the case, may i suggest that we add this information to the end instructions property instead. This may save someone the time it takes to debug and find solution from documentation like i did.