### PR TITLE
Tip for Enabling SSL for Hedgedoc configuration

### DIFF
--- a/public/v4/apps/hedgedoc.yml
+++ b/public/v4/apps/hedgedoc.yml
@@ -9,7 +9,6 @@ services:
             CMD_DOMAIN: $$cap_appname.$$cap_root_domain
             CMD_URL_ADDPORT: false
             PLUGIN_INSTALLER: $$cap_plugin_installer
-            CMD_PROTOCOL_USESSL: true
         volumes:
             - '$$cap_appname-uploads:/hedgedoc/public/uploads'
         caproverExtra:
@@ -58,6 +57,7 @@ caproverOneClickApp:
         end: |-
             HedgeDoc has been successfully deployed!
             App is available as http://$$cap_appname.$$cap_root_domain
+            If you plan to enable HTTPS, make sure to set this environment variable: `CMD_PROTOCOL_USESSL=true`
     displayName: HedgeDoc
     isOfficial: true
     description: HedgeDoc lets you create real-time collaborative markdown notes


### PR DESCRIPTION
I ran into an issue when installing Hedgedoc and enabling https. It took me some time to find the solution, and I think it'd be great to just add it to the instructions. Ultimately a simple environment variable needs to be set. Hopefully this will save the next person some time. 

This issue has been documented here: https://github.com/hedgedoc/hedgedoc/issues/2314

[Had a previous pull request here for context](https://github.com/caprover/one-click-apps/pull/1257)