### PR TITLE
Update immich to v2.5.2

### DIFF
--- a/public/v4/apps/immich.yml
+++ b/public/v4/apps/immich.yml
@@ -5,7 +5,7 @@ services:
         caproverExtra:
             dockerfileLines:
                 - FROM ghcr.io/immich-app/immich-server:$$cap_version
-            containerHttpPort: 3001
+            containerHttpPort: 2283
         environment:
             DB_PASSWORD: $$cap_app_db_pass
             DB_USERNAME: $$cap_app_db_user
@@ -38,17 +38,19 @@ services:
     $$cap_appname-redis:
         caproverExtra:
             notExposeAsWebApp: 'true'
-        image: redis:$$cap_redis_ver
+        image: redis:$$cap_redis_version
 
     $$cap_appname-db:
         caproverExtra:
             notExposeAsWebApp: 'true'
-        image: tensorchord/pgvecto-rs:$$cap_app_db_ver
+        image: ghcr.io/immich-app/postgres:$$cap_postgres_version
         environment:
             POSTGRES_PASSWORD: $$cap_app_db_pass
             POSTGRES_USER: $$cap_app_db_user
             POSTGRES_DB: $$cap_app_db_name
+            POSTGRES_INITDB_ARGS: '--data-checksums'
             PG_DATA: /var/lib/postgresql/data
+            DB_STORAGE_TYPE: $$cap_db_storage_type
         volumes:
             - $$cap_appname-db-data:/var/lib/postgresql/data
 
@@ -67,11 +69,15 @@ caproverOneClickApp:
         - label: Immich version
           id: $$cap_version
           description: Check out their valid tags at https://github.com/immich-app/immich/releases
-          defaultValue: v1.108.0
-        - label: Immich redis version
-          id: $$cap_redis_ver
-          defaultValue: 6.2-alpine@sha256:c5a607fb6e1bb15d32bbcf14db22787d19e428d59e31a5da67511b49bb0f1ccc
+          defaultValue: v2.5.2
+        - label: PostgreSQL database version
+          id: $$cap_postgres_version
+          description: Check valid tags at https://github.com/immich-app/base-images/pkgs/container/postgres
+          defaultValue: 14-vectorchord0.4.3-pgvectors0.2.0
+        - label: Redis version
+          id: $$cap_redis_version
           description: Check out their valid tags at https://hub.docker.com/_/redis/tags
+          defaultValue: 8.4
         - label: Database password
           id: $$cap_app_db_pass
           description: Password for accessing the database. A random one has been generated for you.
@@ -84,11 +90,12 @@ caproverOneClickApp:
           id: $$cap_app_db_name
           description: A name for the database used by Immich
           defaultValue: 'immich'
-        - label: PostgreSQL database version
-          id: $$cap_app_db_ver
-          description: Immich uses PostgreSQL with the pgvecto.rs extension. Check the valid tags at https://hub.docker.com/r/tensorchord/pgvecto-rs/tags
-          defaultValue: pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
         - label: Upload directory
           id: $$cap_app_upload_location
           description: Full path to the directory where you plan to store all your files. It should be created beforehand. If you want caprover to create it for you just leave the default 'immich-data'
           defaultValue: immich-data
+        - label: Database storage type
+          id: $$cap_db_storage_type
+          description: Set to 'HDD' if your database is stored on a hard drive (not SSD). Leave empty for SSD (default).
+          defaultValue: ''
+          validRegex: /^(HDD|)$/


### PR DESCRIPTION
Based on the docker-compose.yml found here:
https://docs.immich.app/overview/quick-start

- Changing default container port to 2283.
- adding vectorchord postgres database
- adding support for setting HDD variable

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [ ] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] Icon is added as a png file to the logos directory.
- [ ] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [ ] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
