### PR TITLE
Update Vikunja to v2.3 with PostgreSQL

### DIFF
--- a/public/v4/apps/vikunja.yml
+++ b/public/v4/apps/vikunja.yml
@@ -93,4 +93,4 @@ services:
             POSTGRES_PASSWORD: $$cap_POSTGRES_PASSWORD
             POSTGRES_DB: $$cap_POSTGRES_DATABASE
         volumes:
-            - $$cap_appname-db:/var/lib/postgresql/data
+            - $$cap_appname-db:/var/lib/postgresql

--- a/public/v4/apps/vikunja.yml
+++ b/public/v4/apps/vikunja.yml
@@ -2,10 +2,17 @@ captainVersion: 4
 caproverOneClickApp:
     instructions:
         start: |-
-            Vikunja is an open-source task management application that helps you keep track of your tasks and projects.
-            To get started, follow the instructions below to deploy Vikunja on your CapRover server.
+            Vikunja is an open-source task management application that helps you organize tasks, projects, and more.
+
+            This deploys Vikunja v2.x with PostgreSQL 18 as the database backend (recommended by Vikunja).
+
+            You will need to set the public URL where Vikunja will be accessible. Make sure to configure your custom domain and enable HTTPS before using the app.
         end: |-
-            Vikunja has been successfully deployed! You can access it at the URL you provided during setup. The initial application setup (like creating your first user) will occur upon your first visit to this URL. Enjoy managing your tasks with Vikunja!
+            Vikunja has been successfully deployed!
+
+            Access it at the URL you provided during setup. The first user you register will become the admin.
+
+            Important: Make sure the public URL matches your actual domain (including https:// if you enable SSL).
     displayName: Vikunja
     isOfficial: false
     description: Open Source Task Management
@@ -13,54 +20,49 @@ caproverOneClickApp:
     variables:
         - id: $$cap_VIKUNJA_VERSION
           label: Vikunja Version
-          description: Check out their valid tags at https://hub.docker.com/r/vikunja/vikunja/tags
-          defaultValue: '0.24'
+          description: Check out valid tags at https://hub.docker.com/r/vikunja/vikunja/tags
+          defaultValue: '2.3'
           validRegex: /.{1,}/
-        - id: $$cap_MARIADB_VERSION
-          label: MariaDB Version
-          description: Check out their valid tags at https://hub.docker.com/_/mariadb/tags
-          defaultValue: '11.7'
+        - id: $$cap_POSTGRES_VERSION
+          label: PostgreSQL Version
+          description: Check out valid tags at https://hub.docker.com/_/postgres/tags
+          defaultValue: '18'
           validRegex: /.{1,}/
-        - id: $$cap_JWT_SECRET_KEY
-          label: JWT Secret Key
-          description: A random string used for JSON Web Tokens (JWT).
+        - id: $$cap_SERVICE_SECRET
+          label: Service Secret
+          description: A random secret used for JWT signing and encryption. Must be set, otherwise it regenerates on each restart.
           defaultValue: $$cap_gen_random_hex(32)
           validRegex: /.{1,}/
-        - id: $$cap_MARIADB_DATABASE
-          label: Database
-          description: The name of the MariaDB database.
+        - id: $$cap_POSTGRES_DATABASE
+          label: Database Name
+          description: The name of the PostgreSQL database.
           defaultValue: vikunja
           validRegex: /.{1,}/
-        - id: $$cap_MARIADB_USER
+        - id: $$cap_POSTGRES_USER
           label: Database User
-          description: The user of the MariaDB database.
+          description: The PostgreSQL database user.
           defaultValue: vikunja
           validRegex: /.{1,}/
-        - id: $$cap_MARIADB_PASSWORD
+        - id: $$cap_POSTGRES_PASSWORD
           label: Database Password
-          description: The password of the MariaDB database.
-          defaultValue: $$cap_gen_random_hex(16)
-          validRegex: /.{1,}/
-        - id: $$cap_MARIADB_ROOT_PASSWORD
-          label: Database Root User Password
-          description: The password of the MariaDB database root user.
+          description: The PostgreSQL database password.
           defaultValue: $$cap_gen_random_hex(16)
           validRegex: /.{1,}/
         - id: $$cap_APP_URL
-          label: Vikunja URL
-          description: The URL of the Vikunja application.
-          defaultValue: https://vikunja.example.com
-          validRegex: /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(:\d+)?(\/.*)?$/
+          label: Vikunja Public URL
+          description: The full URL where Vikunja will be accessible (e.g., https://tasks.example.com). Required for CORS and link generation.
+          defaultValue: https://tasks.example.com
+          validRegex: /^https?:\/\/.+$/
         - id: $$cap_TIMEZONE
           label: Timezone
-          description: The timezone of the Vikunja application (e.g., 'UTC', 'Europe/Berlin'). Use TZ database names.
+          description: Timezone for timestamps (e.g., UTC, America/New_York). Uses TZ database names.
           defaultValue: UTC
           validRegex: /.{1,}/
-        - id: $$cap_WEEK_START
-          label: Week Start
-          description: The first day of the week. 0 = Sunday, 1 = Monday, etc.
-          defaultValue: 1
-          validRegex: /^(0|1|2|3|4|5|6)$/
+        - id: $$cap_ENABLE_REGISTRATION
+          label: Enable Registration
+          description: Allow new users to register. Set to false to disable after creating your account.
+          defaultValue: 'true'
+          validRegex: /^(true|false)$/
 
 services:
     $$cap_appname:
@@ -69,14 +71,14 @@ services:
         image: vikunja/vikunja:$$cap_VIKUNJA_VERSION
         environment:
             VIKUNJA_SERVICE_PUBLICURL: $$cap_APP_URL
-            VIKUNJA_DATABASE_HOST: srv-captain--$$cap_appname-db
-            VIKUNJA_DATABASE_TYPE: mysql
-            VIKUNJA_DATABASE_USER: $$cap_MARIADB_USER
-            VIKUNJA_DATABASE_PASSWORD: $$cap_MARIADB_PASSWORD
-            VIKUNJA_DATABASE_DATABASE: $$cap_MARIADB_DATABASE
-            VIKUNJA_SERVICE_JWTSECRET: $$cap_JWT_SECRET_KEY
+            VIKUNJA_SERVICE_SECRET: $$cap_SERVICE_SECRET
             VIKUNJA_SERVICE_TIMEZONE: $$cap_TIMEZONE
-            VIKUNJA_DEFAULTSETTINGS_WEEK_START: $$cap_WEEK_START
+            VIKUNJA_SERVICE_ENABLEREGISTRATION: $$cap_ENABLE_REGISTRATION
+            VIKUNJA_DATABASE_TYPE: postgres
+            VIKUNJA_DATABASE_HOST: srv-captain--$$cap_appname-db
+            VIKUNJA_DATABASE_USER: $$cap_POSTGRES_USER
+            VIKUNJA_DATABASE_PASSWORD: $$cap_POSTGRES_PASSWORD
+            VIKUNJA_DATABASE_DATABASE: $$cap_POSTGRES_DATABASE
         volumes:
             - $$cap_appname-files:/app/vikunja/files
         depends_on:
@@ -85,11 +87,10 @@ services:
     $$cap_appname-db:
         caproverExtra:
             notExposeAsWebApp: 'true'
-        image: mariadb:$$cap_MARIADB_VERSION
+        image: postgres:$$cap_POSTGRES_VERSION
         environment:
-            MYSQL_ROOT_PASSWORD: $$cap_MARIADB_ROOT_PASSWORD
-            MYSQL_USER: $$cap_MARIADB_USER
-            MYSQL_PASSWORD: $$cap_MARIADB_PASSWORD
-            MYSQL_DATABASE: $$cap_MARIADB_DATABASE
+            POSTGRES_USER: $$cap_POSTGRES_USER
+            POSTGRES_PASSWORD: $$cap_POSTGRES_PASSWORD
+            POSTGRES_DB: $$cap_POSTGRES_DATABASE
         volumes:
-            - $$cap_appname-db:/var/lib/mysql
+            - $$cap_appname-db:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary

- Bump Vikunja from 0.24 to 2.3 (major version upgrade to the v2.x rewrite)
- Switch database from MariaDB to PostgreSQL 18 (now recommended by Vikunja upstream)
- Update JWT secret env var from `VIKUNJA_SERVICE_JWTSECRET` to `VIKUNJA_SERVICE_SECRET` (breaking change in v2.x)
- Add registration toggle (`VIKUNJA_SERVICE_ENABLEREGISTRATION`)
- Remove week start setting (now configurable in the Vikunja UI)
- Remove MariaDB root password variable (not needed with PostgreSQL)

## References

- Vikunja Docker docs: https://vikunja.io/docs/full-docker-example
- Vikunja config options: https://vikunja.io/docs/config-options
- Docker Hub: https://hub.docker.com/r/vikunja/vikunja/tags



----


First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
