### PR TITLE
Update uptime-kuma.yml

### DIFF
--- a/public/v4/apps/uptime-kuma.yml
+++ b/public/v4/apps/uptime-kuma.yml
@@ -13,7 +13,7 @@ caproverOneClickApp:
     variables:
         - id: $$cap_kuma_version
           label: Uptime Kuma Version
-          defaultValue: 1.23.11
+          defaultValue: 2.3.2
           description: Check out their Docker page for the valid tags https://hub.docker.com/r/louislam/uptime-kuma/tags
     instructions:
         start: |-


### PR DESCRIPTION
Update uptime kuma one-click-app to the latest release version: https://github.com/louislam/uptime-kuma. It was throwing errors upon app creation as the current default value no longer exists.

First of all, thank you for your contribution! 😄

Please note that this repo is mostly for popular apps with thousands of stars and tens of thousands of downloads. If you'd like to add a less popular app, you can always [create your own 3rd party repo](https://github.com/caprover/one-click-apps#build-your-own-one-click-app-repository) and add your app there.


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
