### PR TITLE
Update Ghost based on Official Image

### DIFF
--- a/public/v4/apps/ghost-only.yml
+++ b/public/v4/apps/ghost-only.yml
@@ -2,112 +2,89 @@ captainVersion: 4
 services:
     $$cap_appname:
         environment:
-            GHOST_DATABASE_NAME: $$cap_ghost_database_name
-            GHOST_DATABASE_PASSWORD: $$cap_ghost_database_password
-            GHOST_DATABASE_USER: $$cap_ghost_database_user
-            GHOST_EMAIL: $$cap_ghost_email
-            GHOST_HOST: $$cap_ghost_host
-            GHOST_PASSWORD: $$cap_ghost_password
-            GHOST_ENABLE_HTTPS: $$cap_ghost_protocol
-            GHOST_PORT_NUMBER: $$cap_ghost_port
-            GHOST_DATABASE_HOST: $$cap_db_host
-            GHOST_DATABASE_PORT_NUMBER: $$cap_db_port_number
-            GHOST_SMTP_FROM_ADDRESS: $$cap_ghost_smtp_from
-            GHOST_SMTP_HOST: $$cap_ghost_smtp_host
-            GHOST_SMTP_PASSWORD: $$cap_ghost_smtp_password
-            GHOST_SMTP_PORT: $$cap_ghost_smtp_port
-            GHOST_SMTP_USER: $$cap_ghost_smtp_user
-            GHOST_SMTP_PROTOCOL: $$cap_ghost_smtp_protocol
-        image: bitnamilegacy/ghost:$$cap_ghost_version
+            NODE_ENV: production
+            url: https://$$cap_ghost_host
+            database__client: mysql
+            database__connection__host: $$cap_db_host
+            database__connection__port: $$cap_db_port
+            database__connection__user: $$cap_db_user
+            database__connection__password: $$cap_db_password
+            database__connection__database: $$cap_db_name
+            mail__transport: SMTP
+            mail__options__host: $$cap_smtp_host
+            mail__options__port: $$cap_smtp_port
+            mail__options__secure: $$cap_smtp_secure
+            mail__options__auth__user: $$cap_smtp_user
+            mail__options__auth__pass: $$cap_smtp_password
+            mail__from: $$cap_smtp_from
+        image: ghost:$$cap_ghost_version
         restart: always
         volumes:
-            - $$cap_appname-data:/bitnami/ghost
+            - $$cap_appname-data:/var/lib/ghost/content
         caproverExtra:
             containerHttpPort: '2368'
 caproverOneClickApp:
     variables:
-        - defaultValue: 5.2.2
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/bitnamilegacy/ghost/tags
+        - defaultValue: 6-alpine
+          description: Check available tags at https://hub.docker.com/_/ghost/tags
           id: $$cap_ghost_version
           label: Ghost Version
           validRegex: /^([^\s^\/])+$/
-        - description: DB Host
-          defaultValue: localhost
+        - description: Database host (e.g. srv-captain--your-db)
           id: $$cap_db_host
           label: DB Host
-        - description: DB port
-          defaultValue: '3306'
-          id: $$cap_db_port_number
+        - defaultValue: '3306'
+          description: Database port
+          id: $$cap_db_port
           label: DB port
-        - description: Database name
-          defaultValue: ghost
-          id: $$cap_ghost_database_name
-          label: Ghost Database name
-          validRegex: /^([^\s^\/])+$/
-        - description: User for database
-          id: $$cap_ghost_database_user
-          label: DB User
-          validRegex: /^([^\s^\/])+$/
-        - description: Password for database
-          id: $$cap_ghost_database_password
-          label: Ghost DB password
-          validRegex: /^(?=.*\d).{10,}$/
-        - defaultValue: youremail@example.com
-          description: Ghost administrator email, you will use it to login
-          id: $$cap_ghost_email
-          label: Ghost email
-          validRegex: /^([^\s^\/])+$/
-        - description: The admin password must be at least 10 characters, and at least one number and letter
-          id: $$cap_ghost_password
-          label: Ghost password
-          validRegex: /^(?=.*\d).{10,}$/
+        - defaultValue: ghost
+          description: Database name
+          id: $$cap_db_name
+          label: DB name
+        - defaultValue: ghost
+          description: Database user
+          id: $$cap_db_user
+          label: DB user
+        - description: Database password
+          id: $$cap_db_password
+          label: DB password
         - defaultValue: blog.example.com
-          description: Enter the URL that is used to access your publication
+          description: Your custom domain (e.g. blog.example.com)
           id: $$cap_ghost_host
           label: Ghost Host
           validRegex: /^([^\s^\/])+$/
-        - defaultValue: 'yes'
-          description: Enable serving Ghost through HTTPS instead of HTTP
-          id: $$cap_ghost_protocol
-          label: Ghost Protocol
-          validRegex: /^([^\s^\/])+$/
-        - defaultValue: '2368'
-          description: Port that you will be using
-          id: $$cap_ghost_port
-          label: Ghost Port
-        - description: The SMTP protocol to use. Allowed values tls, ssl. No default.
-          id: $$cap_ghost_smtp_protocol
-          label: '[OPTIONAL] STMP protocol'
-        - defaultValue: smtp.gmail.com
-          description: The STMP host you will be using
-          id: $$cap_ghost_smtp_host
-          label: STMP host
-        - defaultValue: '465'
-          description: The SMTP port you will be using
-          id: $$cap_ghost_smtp_port
+        - defaultValue: smtp.example.com
+          description: SMTP server host
+          id: $$cap_smtp_host
+          label: SMTP host
+        - defaultValue: '587'
+          description: SMTP server port
+          id: $$cap_smtp_port
           label: SMTP port
-        - defaultValue: your_email@gmail.com
-          description: Your user on the SMTP service
-          id: $$cap_ghost_smtp_user
+        - defaultValue: 'false'
+          description: Use TLS/SSL (true for port 465, false for port 587)
+          id: $$cap_smtp_secure
+          label: SMTP secure
+        - defaultValue: support@example.com
+          description: SMTP username
+          id: $$cap_smtp_user
           label: SMTP user
-        - description: Your password on the SMTP service
-          id: $$cap_ghost_smtp_password
+        - description: SMTP password
+          id: $$cap_smtp_password
           label: SMTP password
-        - defaultValue: your_email@gmail.com
-          description: SMTP from address
-          id: $$cap_ghost_smtp_from
+        - defaultValue: "'Ghost' <support@example.com>"
+          description: SMTP from address for emails
+          id: $$cap_smtp_from
           label: SMTP from address
     instructions:
         end: >
-            Ghost is deployed and available as $$cap_appname. 
+            Ghost is deployed and available at https://$$cap_ghost_host
 
-            Before starting using Ghost, you'll need to
+            Complete your setup by visiting https://$$cap_ghost_host/ghost
 
-            - Enable HTTPS
-
-            IMPORTANT: It will take up to 2 minutes for Ghost to be ready. Before that, you might see 502 error page.
+            IMPORTANT: It may take up to 2 minutes for Ghost to be ready. Before that, you might see a 502 error.
         start: Ghost is a fully open source, adaptable platform for building and running a modern online publication. We power blogs, magazines and journalists from Zappos to Sky News.
     displayName: Ghost - No Database
     isOfficial: true
-    description: This will create a Ghost blog without a database. After installation you will need to change config.production.json, theres a bug where the port number is in the url.
-    documentation: Taken from https://docs.ghost.org/
+    description: Ghost is a free and open source blogging platform written in JavaScript and distributed under the MIT License. This variant expects an external MySQL/MariaDB database.
+    documentation: Taken from https://docs.ghost.org/install/docker/

--- a/public/v4/apps/ghost-only.yml
+++ b/public/v4/apps/ghost-only.yml
@@ -25,7 +25,7 @@ services:
             containerHttpPort: '2368'
 caproverOneClickApp:
     variables:
-        - defaultValue: 6-alpine
+        - defaultValue: 6.44.0-alpine
           description: Check available tags at https://hub.docker.com/_/ghost/tags
           id: $$cap_ghost_version
           label: Ghost Version
@@ -80,9 +80,17 @@ caproverOneClickApp:
         end: >
             Ghost is deployed and available at https://$$cap_ghost_host
 
-            Complete your setup by visiting https://$$cap_ghost_host/ghost
+            IMPORTANT: Before using Ghost, you MUST:
 
-            IMPORTANT: It may take up to 2 minutes for Ghost to be ready. Before that, you might see a 502 error.
+            1. Point your domain ($$cap_ghost_host) DNS A-Record to your CapRover server IP
+
+            2. In CapRover, go to Apps > $$cap_appname > HTTP Settings and add $$cap_ghost_host
+
+            3. Enable HTTPS for the domain via CapRover's SSL section (Let's Encrypt)
+
+            4. Complete your setup by visiting https://$$cap_ghost_host/ghost
+
+            It may take up to 2 minutes for Ghost to be ready. Before that, you might see a 502 error.
         start: Ghost is a fully open source, adaptable platform for building and running a modern online publication. We power blogs, magazines and journalists from Zappos to Sky News.
     displayName: Ghost - No Database
     isOfficial: true

--- a/public/v4/apps/ghost.yml
+++ b/public/v4/apps/ghost.yml
@@ -35,10 +35,10 @@ services:
         volumes:
             - $$cap_appname-db-data:/var/lib/mysql
         caproverExtra:
-            notExposeAsWebApp: 'true'
+            notExposeAsWebApp: true
 caproverOneClickApp:
     variables:
-        - defaultValue: 6-alpine
+        - defaultValue: 6.44.0-alpine
           description: Check available tags at https://hub.docker.com/_/ghost/tags
           id: $$cap_ghost_version
           label: Ghost Version
@@ -46,10 +46,12 @@ caproverOneClickApp:
         - description: Root password for MySQL
           id: $$cap_db_root_password
           label: MySQL root password
+          defaultValue: $$cap_gen_random_hex(12)
           validRegex: /^(?=.*\d).{10,}$/
         - description: Password for the Ghost database user
           id: $$cap_db_password
           label: MySQL Ghost password
+          defaultValue: $$cap_gen_random_hex(12)
           validRegex: /^(?=.*\d).{10,}$/
         - defaultValue: blog.example.com
           description: Your custom domain (e.g. blog.example.com)
@@ -83,9 +85,17 @@ caproverOneClickApp:
         end: >
             Ghost is deployed and available at https://$$cap_ghost_host
 
-            Complete your setup by visiting https://$$cap_ghost_host/ghost
+            IMPORTANT: Before using Ghost, you MUST:
 
-            IMPORTANT: It may take up to 2 minutes for Ghost to be ready. Before that, you might see a 502 error.
+            1. Point your domain ($$cap_ghost_host) DNS A-Record to your CapRover server IP
+
+            2. In CapRover, go to Apps > $$cap_appname > HTTP Settings and add $$cap_ghost_host
+
+            3. Enable HTTPS for the domain via CapRover's SSL section (Let's Encrypt)
+
+            4. Complete your setup by visiting https://$$cap_ghost_host/ghost
+
+            It may take up to 2 minutes for Ghost to be ready. Before that, you might see a 502 error.
         start: Ghost is a fully open source, adaptable platform for building and running a modern online publication. We power blogs, magazines and journalists from Zappos to Sky News.
     displayName: 'Ghost'
     isOfficial: true

--- a/public/v4/apps/ghost.yml
+++ b/public/v4/apps/ghost.yml
@@ -2,130 +2,92 @@ captainVersion: 4
 services:
     $$cap_appname:
         environment:
-            GHOST_DATABASE_NAME: ghost
-            GHOST_DATABASE_PASSWORD: $$cap_db_ghost_password
-            GHOST_DATABASE_USER: ghost
-            GHOST_BLOG_TITLE: $$cap_ghost_blog_title
-            GHOST_USERNAME: $$cap_ghost_user
-            GHOST_EMAIL: $$cap_ghost_email
-            GHOST_HOST: $$cap_ghost_host
-            GHOST_PASSWORD: $$cap_ghost_password
-            GHOST_ENABLE_HTTPS: $$cap_ghost_protocol
-            GHOST_PORT_NUMBER: $$cap_ghost_port
-            GHOST_DATABASE_HOST: srv-captain--$$cap_appname-db
-            GHOST_DATABASE_PORT_NUMBER: '3306'
-            GHOST_SMTP_FROM_ADDRESS: $$cap_ghost_smtp_from
-            GHOST_SMTP_HOST: $$cap_ghost_smtp_host
-            GHOST_SMTP_PASSWORD: $$cap_ghost_smtp_password
-            GHOST_SMTP_PORT: $$cap_ghost_smtp_port
-            GHOST_SMTP_USER: $$cap_ghost_smtp_user
-            GHOST_SMTP_PROTOCOL: $$cap_ghost_smtp_protocol
-        image: bitnamilegacy/ghost:$$cap_ghost_version
+            NODE_ENV: production
+            url: https://$$cap_ghost_host
+            database__client: mysql
+            database__connection__host: srv-captain--$$cap_appname-db
+            database__connection__user: ghost
+            database__connection__password: $$cap_db_password
+            database__connection__database: ghost
+            mail__transport: SMTP
+            mail__options__host: $$cap_smtp_host
+            mail__options__port: $$cap_smtp_port
+            mail__options__secure: $$cap_smtp_secure
+            mail__options__auth__user: $$cap_smtp_user
+            mail__options__auth__pass: $$cap_smtp_password
+            mail__from: $$cap_smtp_from
+        image: ghost:$$cap_ghost_version
         restart: always
         volumes:
-            - $$cap_appname-data:/bitnami/ghost
+            - $$cap_appname-data:/var/lib/ghost/content
         depends_on:
             - $$cap_appname-db
         caproverExtra:
             containerHttpPort: '2368'
     $$cap_appname-db:
         environment:
-            MYSQL_DATABASE: ghost
-            MYSQL_PASSWORD: $$cap_db_ghost_password
-            MYSQL_ROOT_PASSWORD: $$cap_db_password
-            MYSQL_ROOT_USER: $$cap_db_user
+            MYSQL_ROOT_PASSWORD: $$cap_db_root_password
             MYSQL_USER: ghost
-        image: bitnamilegacy/mysql:8.0
+            MYSQL_PASSWORD: $$cap_db_password
+            MYSQL_DATABASE: ghost
+        image: mysql:8.0
         restart: always
         volumes:
-            - $$cap_appname-db-data:/bitnami/mysql
+            - $$cap_appname-db-data:/var/lib/mysql
         caproverExtra:
             notExposeAsWebApp: 'true'
 caproverOneClickApp:
     variables:
-        - defaultValue: 5.2.2
-          description: Check out their Docker page for the valid tags https://hub.docker.com/r/bitnamilegacy/ghost/tags
+        - defaultValue: 6-alpine
+          description: Check available tags at https://hub.docker.com/_/ghost/tags
           id: $$cap_ghost_version
           label: Ghost Version
           validRegex: /^([^\s^\/])+$/
-        - defaultValue: admin
-          description: Root user that will be created on DB
-          id: $$cap_db_user
-          label: MYSQL root user
-          validRegex: /^([^\s^\/])+$/
-        - description: Root password that will be created on MYSQL
+        - description: Root password for MySQL
+          id: $$cap_db_root_password
+          label: MySQL root password
+          validRegex: /^(?=.*\d).{10,}$/
+        - description: Password for the Ghost database user
           id: $$cap_db_password
-          label: MYSQL root password
-          validRegex: /^(?=.*\d).{10,}$/
-        - description: Password for database user named `ghost`
-          id: $$cap_db_ghost_password
-          label: MYSQL Ghost password
-          validRegex: /^(?=.*\d).{10,}$/
-        - defaultValue: user
-          description: Ghost administrator user
-          id: $$cap_ghost_user
-          label: Ghost administrator username
-          validRegex: /^([^\s^\/])+$/
-        - defaultValue: youremail@example.com
-          description: Ghost administrator email, you will use it to login
-          id: $$cap_ghost_email
-          label: Ghost administrator email
-          validRegex: /^([^\s^\/])+$/
-        - description: The admin password must be at least 10 characters, and at least one number and letter
-          id: $$cap_ghost_password
-          label: Ghost password
+          label: MySQL Ghost password
           validRegex: /^(?=.*\d).{10,}$/
         - defaultValue: blog.example.com
-          description: Enter the URL that is used to access your publication
+          description: Your custom domain (e.g. blog.example.com)
           id: $$cap_ghost_host
           label: Ghost Host
           validRegex: /^([^\s^\/])+$/
-        - defaultValue: 'yes'
-          description: Enable serving Ghost through HTTPS instead of HTTP
-          id: $$cap_ghost_protocol
-          label: Ghost Protocol
-          validRegex: /^([^\s^\/])+$/
-        - defaultValue: '2368'
-          description: Port that you will be using
-          id: $$cap_ghost_port
-          label: Ghost Port
-        - defaultValue: 'User blog'
-          description: Blog name that will be displayed
-          id: $$cap_ghost_blog_title
-          label: Ghost Blog Title
-        - defaultValue: smtp.gmail.com
-          description: The SMTP host you will be using
-          id: $$cap_ghost_smtp_host
+        - defaultValue: smtp.example.com
+          description: SMTP server host
+          id: $$cap_smtp_host
           label: SMTP host
         - defaultValue: '587'
-          description: The SMTP port you will be using
-          id: $$cap_ghost_smtp_port
+          description: SMTP server port
+          id: $$cap_smtp_port
           label: SMTP port
-        - defaultValue: your_email@gmail.com
-          description: Your user on the SMTP service
-          id: $$cap_ghost_smtp_user
+        - defaultValue: 'false'
+          description: Use TLS/SSL (true for port 465, false for port 587)
+          id: $$cap_smtp_secure
+          label: SMTP secure
+        - defaultValue: support@example.com
+          description: SMTP username
+          id: $$cap_smtp_user
           label: SMTP user
-        - description: Your password on the SMTP service
-          id: $$cap_ghost_smtp_password
+        - description: SMTP password
+          id: $$cap_smtp_password
           label: SMTP password
-        - description: The SMTP protocol to use. Allowed values tls, ssl. No default.
-          id: $$cap_ghost_smtp_protocol
-          label: '[OPTIONAL] SMTP protocol'
-        - defaultValue: blog@example.com
-          description: SMTP from address
-          id: $$cap_ghost_smtp_from
+        - defaultValue: "'Ghost' <support@example.com>"
+          description: From address for emails
+          id: $$cap_smtp_from
           label: SMTP from address
     instructions:
         end: >
-            Ghost is deployed and available as $$cap_appname. 
+            Ghost is deployed and available at https://$$cap_ghost_host
 
-            Before starting using Ghost, you'll need to
+            Complete your setup by visiting https://$$cap_ghost_host/ghost
 
-            - Enable HTTPS
-
-            IMPORTANT: It will take up to 2 minutes for Ghost to be ready. Before that, you might see 502 error page.
+            IMPORTANT: It may take up to 2 minutes for Ghost to be ready. Before that, you might see a 502 error.
         start: Ghost is a fully open source, adaptable platform for building and running a modern online publication. We power blogs, magazines and journalists from Zappos to Sky News.
     displayName: 'Ghost'
     isOfficial: true
     description: Ghost is a free and open source blogging platform written in JavaScript and distributed under the MIT License
-    documentation: Taken from https://docs.ghost.org/
+    documentation: Taken from https://docs.ghost.org/install/docker/


### PR DESCRIPTION
This PR will remove the BitnamiLegacy installers for Ghost CMS and switches to OCAs to official images of Ghost.
Both OCAs tested against [6.44.0-alpine](https://hub.docker.com/layers/library/ghost/6.44.0-alpine/images/sha256-3792c10914261b4a8214008600fa9852e4dd751be366dfb734bc0f5b404370b7)

> Switching current installs to official image is also possible that will be explained in later comments.


</details>

</details>

</details>

### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).
