### PR TITLE
libredb-studio: bump default version to 0.9.59

### DIFF
--- a/public/v4/apps/libredb-studio.yml
+++ b/public/v4/apps/libredb-studio.yml
@@ -27,8 +27,8 @@ caproverOneClickApp:
     variables:
         - id: $$cap_version
           label: LibreDB Studio Version
-          defaultValue: '0.9.14'
-          description: Image tag to deploy. Always pin a fixed version, never "latest". Example - 0.9.14. Browse all valid tags at https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio
+          defaultValue: '0.9.59'
+          description: Image tag to deploy. Always pin a fixed version, never "latest". Example - 0.9.59. Browse all valid tags at https://github.com/libredb/libredb-studio/pkgs/container/libredb-studio
           validRegex: '/^([^\s^\/])+$/'
         - id: $$cap_admin_email
           label: Admin Email


### PR DESCRIPTION
The pre-filled version for LibreDB Studio was still `0.9.14`; the current release is `0.9.59`. Bumps `defaultValue` and the matching example in the variable's description.

Tested before submitting: `npm run validate_apps` passes (`Validated libredb-studio`) and `prettier --check` is clean. The template was also filled in the way CapRover does it (generated hex values for the password variables) and run locally on 0.9.59 — health endpoint green, login works with the generated admin password, and a saved connection survives a restart on the mounted volume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default LibreDB Studio deployment version to 0.9.59.
  * New deployments will use the latest default version unless a custom version is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->