### PR TITLE
Bump filebrowser version and add notice about archive status

### DIFF
--- a/public/v4/apps/filebrowser.yml
+++ b/public/v4/apps/filebrowser.yml
@@ -15,7 +15,7 @@ caproverOneClickApp:
         - id: $$cap_filebrowser_version
           label: File Browser Version Tag
           description: 'Check out their Docker page for the valid tags: https://hub.docker.com/r/filebrowser/filebrowser/tags'
-          defaultValue: v2.36.1-s6
+          defaultValue: v2.63.23
           validRegex: /^([^\s^\/])+$/
     instructions:
         start: >-
@@ -25,6 +25,8 @@ caproverOneClickApp:
             IMPORTANT:
 
             The default image maps an empty volume to FileBrowser in order to avoid exposing your files, but after you finished installation and changed the password you can mount the root directory of host. i.e. / to /srv in the app.
+
+            NOTE: Filebrowser is archived on 2026-09-01 and there will no longer be further releases, bug fixes, or security fixes. This one click app uses the latest available image. Please read https://hacdias.com/2026/07/28/filebrowser/ for more information.
         end: >-
             Important! Read this and take a screenshot so you can refer to it!
 

--- a/public/v4/apps/filebrowser.yml
+++ b/public/v4/apps/filebrowser.yml
@@ -15,7 +15,7 @@ caproverOneClickApp:
         - id: $$cap_filebrowser_version
           label: File Browser Version Tag
           description: 'Check out their Docker page for the valid tags: https://hub.docker.com/r/filebrowser/filebrowser/tags'
-          defaultValue: v2.63.23
+          defaultValue: v2.63.23-s6
           validRegex: /^([^\s^\/])+$/
     instructions:
         start: >-


### PR DESCRIPTION
### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory.
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter` (If failling run the prettier: `npm run formatter-write`)
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).

### Notes

As mentioned in the note that I added, Filebrowser will no longer be maintained starting September 1st, so this PR bumps the one-click-app dfn to the latest image that will be published and explicitly states the status of the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the default FileBrowser image to a newer version.
  * Added an installation notice that FileBrowser is archived and will no longer receive releases, bug fixes, or security updates.
  * Directed users to the project announcement for additional details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->