### PR TITLE
Update outline to 1.9.2 and use local file storage by default

### DIFF
--- a/public/v4/apps/outline.yml
+++ b/public/v4/apps/outline.yml
@@ -15,7 +15,14 @@ services:
         image: redis:$$cap_redis_version
         # the redis image entrypoint is a wrapper, so the command has to start
         # with the binary itself, otherwise CapRover replaces the entrypoint
-        command: ['redis-server', '--appendonly', 'yes', '--requirepass', '$$cap_redis_password']
+        command:
+            [
+                'redis-server',
+                '--appendonly',
+                'yes',
+                '--requirepass',
+                '$$cap_redis_password',
+            ]
         volumes:
             - $$cap_appname-redis-data:/data
         restart: always

--- a/public/v4/apps/outline.yml
+++ b/public/v4/apps/outline.yml
@@ -15,7 +15,7 @@ services:
         image: redis:$$cap_redis_version
         # the redis image entrypoint is a wrapper, so the command has to start
         # with the binary itself, otherwise CapRover replaces the entrypoint
-        command: ['redis-server', '--appendonly', 'yes']
+        command: ['redis-server', '--appendonly', 'yes', '--requirepass', '$$cap_redis_password']
         volumes:
             - $$cap_appname-redis-data:/data
         restart: always
@@ -37,7 +37,7 @@ services:
             UTILS_SECRET: $$cap_utils_secret
             DATABASE_URL: postgres://$$cap_db_user:$$cap_db_pass@srv-captain--$$cap_appname-db:5432/outline
             PGSSLMODE: disable
-            REDIS_URL: redis://srv-captain--$$cap_appname-redis:6379
+            REDIS_URL: redis://:$$cap_redis_password@srv-captain--$$cap_appname-redis:6379
             FILE_STORAGE: $$cap_file_storage
             FILE_STORAGE_LOCAL_ROOT_DIR: /var/lib/outline/data
             FILE_STORAGE_UPLOAD_MAX_SIZE: $$cap_upload_max_size
@@ -108,6 +108,11 @@ caproverOneClickApp:
           label: Database password
           defaultValue: $$cap_gen_random_hex(32)
           description: Letters and digits only, it is used inside the database connection URL.
+          validRegex: /^([a-zA-Z0-9]){16,}$/
+        - id: $$cap_redis_password
+          label: Redis password
+          defaultValue: $$cap_gen_random_hex(32)
+          description: Letters and digits only, it is used inside the Redis connection URL.
           validRegex: /^([a-zA-Z0-9]){16,}$/
         - id: $$cap_default_language
           label: The default interface language
@@ -240,7 +245,11 @@ caproverOneClickApp:
              OIDC:   https://$$cap_appname.$$cap_root_domain/auth/oidc.callback
 
             Uploads live in the $$cap_appname-data volume, the database in $$cap_appname-db-data.
-            Back both of them up. Remaining settings are documented at
+            Back up both volumes, and keep a copy of SECRET_KEY, UTILS_SECRET and the database
+            password from the app configuration. A restore that starts with a fresh SECRET_KEY
+            cannot decrypt the old data and locks every existing user out.
+
+            Remaining settings are documented at
             https://github.com/outline/outline/blob/main/.env.sample
     displayName: Outline
     isOfficial: true

--- a/public/v4/apps/outline.yml
+++ b/public/v4/apps/outline.yml
@@ -1,12 +1,5 @@
 captainVersion: 4
 services:
-    $$cap_appname-redis:
-        image: redis:$$cap_redis_version
-        volumes:
-            - $$cap_appname-redis-data:/redis.conf
-        restart: always
-        caproverExtra:
-            notExposeAsWebApp: 'true'
     $$cap_appname-db:
         image: postgres:$$cap_postgres_version
         volumes:
@@ -18,71 +11,94 @@ services:
             POSTGRES_DB: outline
         caproverExtra:
             notExposeAsWebApp: 'true'
+    $$cap_appname-redis:
+        image: redis:$$cap_redis_version
+        # the redis image entrypoint is a wrapper, so the command has to start
+        # with the binary itself, otherwise CapRover replaces the entrypoint
+        command: ['redis-server', '--appendonly', 'yes']
+        volumes:
+            - $$cap_appname-redis-data:/data
+        restart: always
+        caproverExtra:
+            notExposeAsWebApp: 'true'
     $$cap_appname:
+        image: outlinewiki/outline:$$cap_outline_version
         depends_on:
-            - $$cap_appname-redis
             - $$cap_appname-db
+            - $$cap_appname-redis
+        volumes:
+            - $$cap_appname-data:/var/lib/outline/data
+        restart: always
         environment:
+            NODE_ENV: production
+            URL: https://$$cap_appname.$$cap_root_domain
+            PORT: '3000'
             SECRET_KEY: $$cap_secret_key
             UTILS_SECRET: $$cap_utils_secret
             DATABASE_URL: postgres://$$cap_db_user:$$cap_db_pass@srv-captain--$$cap_appname-db:5432/outline
-            DATABASE_URL_TEST: postgres://$$cap_db_user:$$cap_db_pass@srv-captain--$$cap_appname-db:5432/outline-test
             PGSSLMODE: disable
             REDIS_URL: redis://srv-captain--$$cap_appname-redis:6379
-            URL: https://$$cap_appname.$$cap_root_domain
-            PORT: '3000'
-            AWS_S3_UPLOAD_BUCKET_URL: $$cap_s3_storage_url
-            AWS_REGION: $$cap_s3_storage_region
-            AWS_S3_UPLOAD_BUCKET_NAME: $$cap_s3_storage_bucket_name
-            AWS_ACCESS_KEY_ID: $$cap_s3_storage_access_key_id
-            AWS_SECRET_ACCESS_KEY: $$cap_s3_storage_secret_access_key
-            AWS_S3_UPLOAD_MAX_SIZE: '26214400'
-            AWS_S3_FORCE_PATH_STYLE: true
+            FILE_STORAGE: $$cap_file_storage
+            FILE_STORAGE_LOCAL_ROOT_DIR: /var/lib/outline/data
+            FILE_STORAGE_UPLOAD_MAX_SIZE: $$cap_upload_max_size
+            FORCE_HTTPS: 'true'
+            ENABLE_UPDATES: 'true'
+            WEB_CONCURRENCY: '1'
+            DEFAULT_LANGUAGE: $$cap_default_language
+            AWS_ACCESS_KEY_ID: $$cap_s3_access_key_id
+            AWS_SECRET_ACCESS_KEY: $$cap_s3_secret_access_key
+            AWS_REGION: $$cap_s3_region
+            AWS_S3_UPLOAD_BUCKET_NAME: $$cap_s3_bucket_name
+            AWS_S3_UPLOAD_BUCKET_URL: $$cap_s3_bucket_url
+            AWS_S3_FORCE_PATH_STYLE: $$cap_s3_force_path_style
             AWS_S3_ACL: private
             GOOGLE_CLIENT_ID: $$cap_google_client_id
             GOOGLE_CLIENT_SECRET: $$cap_google_client_secret
-            FORCE_HTTPS: 'false'
-            ENABLE_UPDATES: 'false'
-            DEBUG: http
+            OIDC_CLIENT_ID: $$cap_oidc_client_id
+            OIDC_CLIENT_SECRET: $$cap_oidc_client_secret
+            OIDC_AUTH_URI: $$cap_oidc_auth_uri
+            OIDC_TOKEN_URI: $$cap_oidc_token_uri
+            OIDC_USERINFO_URI: $$cap_oidc_userinfo_uri
+            OIDC_LOGOUT_URI: $$cap_oidc_logout_uri
+            OIDC_USERNAME_CLAIM: $$cap_oidc_username_claim
+            OIDC_DISPLAY_NAME: $$cap_oidc_display_name
+            OIDC_SCOPES: $$cap_oidc_scopes
             SMTP_HOST: $$cap_smtp_host
             SMTP_PORT: $$cap_smtp_port
+            SMTP_SECURE: $$cap_smtp_secure
             SMTP_USERNAME: $$cap_smtp_username
             SMTP_PASSWORD: $$cap_smtp_password
             SMTP_FROM_EMAIL: $$cap_smtp_from_email
             SMTP_REPLY_EMAIL: $$cap_smtp_reply_email
-            SMTP_TLS_CIPHERS: $$cap_smtp_tls_ciphers
-            SMTP_SECURE: $$cap_smtp_secure
-            DEFAULT_LANGUAGE: $$cap_default_language
         caproverExtra:
             containerHttpPort: '3000'
-            dockerfileLines:
-                - FROM outlinewiki/outline:$$cap_outline_version
-                - EXPOSE 3000
-                - CMD yarn db:migrate --env production-ssl-disabled; yarn start
+            websocketSupport: 'true'
 caproverOneClickApp:
     variables:
         - id: $$cap_outline_version
           label: Outline Version
-          defaultValue: 0.68.1
+          defaultValue: '1.9.2'
           description: Check out their page for the valid tags https://hub.docker.com/r/outlinewiki/outline/tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_postgres_version
           label: Postgres Version
-          defaultValue: '14.4'
+          defaultValue: 17-alpine
           description: Check out their page for the valid tags https://hub.docker.com/_/postgres?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_redis_version
           label: Redis Version
-          defaultValue: 7.0.2
-          description: Check out their Docker page for the valid tags https://hub.docker.com/_/redis?tab=tags
+          defaultValue: 7.4-alpine
+          description: Check out their page for the valid tags https://hub.docker.com/_/redis?tab=tags
           validRegex: /^([^\s^\/])+$/
         - id: $$cap_secret_key
           label: SECRET_KEY
-          description: 'Run this command to generate a key: `openssl rand -hex 32`'
+          defaultValue: $$cap_gen_random_hex(64)
+          description: Must be exactly 64 hexadecimal characters. Do not change it after the first login or existing users will be locked out.
           validRegex: /^([0-9a-f]){64}$/
         - id: $$cap_utils_secret
           label: UTILS_SECRET
-          description: 'Run this command to generate a key: `openssl rand -hex 32`'
+          defaultValue: $$cap_gen_random_hex(64)
+          description: A second secret, used for the cron endpoint. Keep it different from SECRET_KEY.
           validRegex: /^([0-9a-f]){64}$/
         - id: $$cap_db_user
           label: Database user
@@ -90,77 +106,143 @@ caproverOneClickApp:
           validRegex: /^([a-zA-Z0-9_])+$/
         - id: $$cap_db_pass
           label: Database password
-          description: ''
-          defaultValue: $$cap_gen_random_hex(20)
-          validRegex: /.{8,}/
-        - id: $$cap_s3_storage_url
-          label: S3 Storage compatible API URL for instance Minio, AWS, etc.
-          description: 'NB: You can have your own S3 storage by using the Open Source Minio alternative (there is a Caprover one-click-apps for that)'
-          defaultValue: https://YOUR_S3_STORAGE_PROVIDER_API_URL
-        - id: $$cap_s3_storage_region
-          label: S3 Storage region
-          description: 'Name of the location of the server e.g. "us-west-rack2"'
-          defaultValue: eu-east-1
-        - id: $$cap_s3_storage_bucket_name
-          label: S3 Storage bucket name
-          description: "Log into the Minio dashboard, then select the `Create Bucket` menu option to create a new bucket (e.g. named outline-data). Don't forget to add `Read and Write` policy to the bucket so the Outline app would be able to upload content"
-          defaultValue: outline-data
-        - id: $$cap_s3_storage_access_key_id
-          label: S3 storage Access Key ID
-          description: 'For instance in your Minio instance, create a new user called outline_user for the outline app with a new policy that grants full access inside the bucket (e.g. outlineAppFullAccess - see also https://wiki.generaloutline.com/share/125de1cc-9ff6-424b-8415-0d58c809a40f#h-iam-policy)'
-          defaultValue: outline_user
-        - id: $$cap_s3_storage_secret_access_key
-          label: S3 storage Secret Access Key
-          description: 'For instance in your Minio instance it correponds to the password/secret of above outline_user'
+          defaultValue: $$cap_gen_random_hex(32)
+          description: Letters and digits only, it is used inside the database connection URL.
+          validRegex: /^([a-zA-Z0-9]){16,}$/
+        - id: $$cap_default_language
+          label: The default interface language
+          defaultValue: en_US
+          description: See translate.getoutline.com for a list of available language codes and their rough percentage translated.
+          validRegex: /^([a-z]{2}_[A-Z]{2})$/
+        - id: $$cap_file_storage
+          label: File storage
+          defaultValue: local
+          description: Use "local" to keep uploads in the $$cap_appname-data volume, or "s3" to store them in an S3 compatible bucket. Choosing s3 requires the S3 fields below.
+          validRegex: /^(local|s3)$/
+        - id: $$cap_upload_max_size
+          label: Maximum upload size in bytes
+          defaultValue: '262144000'
+          description: 262144000 is 250 MB.
+          validRegex: /^([0-9])+$/
+        - id: $$cap_s3_bucket_url
+          label: S3 bucket URL (only for s3 file storage)
+          description: 'For AWS use the virtual hosted style URL, e.g. https://my-bucket.s3.us-east-1.amazonaws.com. For MinIO use the API URL of your instance. Leave empty for local file storage.'
+        - id: $$cap_s3_bucket_name
+          label: S3 bucket name (only for s3 file storage)
+          description: The bucket that Outline uploads attachments to. Leave empty for local file storage.
+        - id: $$cap_s3_region
+          label: S3 region (only for s3 file storage)
+          description: 'Region of the bucket, e.g. us-east-1. Leave empty for local file storage.'
+        - id: $$cap_s3_access_key_id
+          label: S3 access key ID (only for s3 file storage)
+          description: Leave empty for local file storage.
+        - id: $$cap_s3_secret_access_key
+          label: S3 secret access key (only for s3 file storage)
+          description: Leave empty for local file storage.
+        - id: $$cap_s3_force_path_style
+          label: S3 force path style
+          defaultValue: 'false'
+          description: Keep false for AWS S3. Most S3 compatible providers such as MinIO need true.
+          validRegex: /^(true|false)$/
         - id: $$cap_google_client_id
           label: Google Client ID
+          description: 'Leave empty if you sign in with OIDC or email. Redirect URI: https://$$cap_appname.$$cap_root_domain/auth/google.callback'
         - id: $$cap_google_client_secret
           label: Google Client Secret
+        - id: $$cap_oidc_client_id
+          label: OIDC Client ID
+          description: 'Leave empty if you sign in with Google or email. Redirect URI: https://$$cap_appname.$$cap_root_domain/auth/oidc.callback'
+        - id: $$cap_oidc_client_secret
+          label: OIDC Client Secret
+        - id: $$cap_oidc_auth_uri
+          label: OIDC authorization URL
+          description: 'For example https://keycloak.example.com/realms/main/protocol/openid-connect/auth'
+        - id: $$cap_oidc_token_uri
+          label: OIDC token URL
+          description: 'For example https://keycloak.example.com/realms/main/protocol/openid-connect/token'
+        - id: $$cap_oidc_userinfo_uri
+          label: OIDC userinfo URL
+          description: 'For example https://keycloak.example.com/realms/main/protocol/openid-connect/userinfo'
+        - id: $$cap_oidc_logout_uri
+          label: OIDC logout URL
+          description: Optional, called when a user signs out of Outline.
+        - id: $$cap_oidc_username_claim
+          label: OIDC username claim
+          defaultValue: preferred_username
+          description: Common values are preferred_username, email or sub.
+        - id: $$cap_oidc_display_name
+          label: OIDC display name
+          defaultValue: OpenID Connect
+          description: The name shown on the sign in button.
+        - id: $$cap_oidc_scopes
+          label: OIDC scopes
+          defaultValue: openid profile email
+          description: Space separated list of scopes to request.
         - id: $$cap_smtp_host
           label: SMTP host
-          description: To support sending outgoing transactional emails such as "document updated" or "you've been invited" you'll need to provide authentication for an SMTP server
+          description: Needed for email sign in, invites and notifications. Leave empty to disable email.
         - id: $$cap_smtp_port
           label: SMTP port
+          description: 587 or 2525 for STARTTLS, 465 for implicit TLS.
+        - id: $$cap_smtp_secure
+          label: SMTP secure
+          defaultValue: 'false'
+          description: Use true for implicit TLS (port 465) and false for STARTTLS (port 587).
+          validRegex: /^(true|false)$/
         - id: $$cap_smtp_username
           label: SMTP username
         - id: $$cap_smtp_password
           label: SMTP password
         - id: $$cap_smtp_from_email
           label: SMTP from email
+          description: The address notifications are sent from, it usually has to be a verified sender on your mail provider.
         - id: $$cap_smtp_reply_email
           label: SMTP reply email
-        - id: $$cap_smtp_tls_ciphers
-          label: SMTP TLS ciphers
-        - id: $$cap_smtp_secure
-          label: SMTP Secure
-          defaultValue: true
-        - id: $$cap_default_language
-          label: The default interface language
-          description: See translate.getoutline.com for a list of available language codes and their rough percentage translated.
-          defaultValue: en_US
     instructions:
-        start: >
+        start: |-
             Outline is an open, extensible, wiki for your team built using React and Node.js.
 
+            This template deploys Outline together with its own Postgres and Redis containers.
+            Attachments are stored on a persistent volume by default, so no S3 bucket is
+            required. You can switch to an S3 compatible bucket with the "File storage" field.
 
-            Outline requires an external authentication provider such as Google/Slack, etc. 
-            If you don't want to rely on those solutions you can use a generic OpenID Connect Server. 
-            For instance you can use the Open Source Keycloak alternative (there is a Caprover one-click-apps for that)
+            On the first visit Outline asks you to create the workspace and the admin account,
+            so you can start without an external login provider. You still need one of the
+            options below to be able to sign in again later:
 
+             1) SMTP, which enables email sign in links
+             2) Google OAuth
+             3) A generic OpenID Connect provider, for example Keycloak or Authentik
 
-            IMPORTANT: You need to, at least, set one 3rd party login method, either Keycloak, Slack or Google
-        end: >
-            IMPORTANT: before you start using Outline, you need to 
+            All of them can be left empty here and filled in later in the app configuration.
+        end: |-
+            Outline has been deployed at https://$$cap_appname.$$cap_root_domain
 
-             1) Enable HTTPS 
-             2) Force HTTPS 
-             3) Enable Websocket in $$cap_appname.
-             4) Configure your authentication method following instructions: https://wiki.generaloutline.com/s/hosting/doc/authentication-7ViKRmRY5o
+            Before you open it:
 
-            You can customize more settings by environmental variables described here: https://github.com/outline/outline/blob/0deecfac446c37545e0787b3d32062e608a950ab/.env.sample 
+             1) Enable HTTPS on $$cap_appname
+             2) Enable Force HTTPS, Outline refuses to sign users in over plain HTTP
 
-            IMPORTANT: It will take up to 2 minutes for it to be ready. Before that, you might see a 502 error page.
+            Websocket support is already enabled by this template, so you do not have to
+            turn it on yourself.
+
+            The first start runs the database migrations, so it can take a minute or two before
+            the site answers. Until then you may see a 502 page. After that, open the site and
+            fill in the "Create workspace" form to create your admin account.
+
+            IMPORTANT: the sign in page is empty until a login method is configured. Set up SMTP,
+            Google or OIDC before your session expires, otherwise you will not be able to sign
+            back in. See https://docs.getoutline.com/s/hosting/doc/authentication-7ViKRmRY5o
+
+            Redirect URIs to register with your identity provider:
+
+             Google: https://$$cap_appname.$$cap_root_domain/auth/google.callback
+             OIDC:   https://$$cap_appname.$$cap_root_domain/auth/oidc.callback
+
+            Uploads live in the $$cap_appname-data volume, the database in $$cap_appname-db-data.
+            Back both of them up. Remaining settings are documented at
+            https://github.com/outline/outline/blob/main/.env.sample
     displayName: Outline
     isOfficial: true
     description: An open, extensible, wiki for your team built using React and Node.js.
-    documentation: Taken from https://github.com/outline/outline/blob/master/docker-compose.yml
+    documentation: Taken from https://github.com/outline/outline


### PR DESCRIPTION
The Outline template had not been touched since 2022. It still pinned Outline 0.68.1, Postgres 14.4 and Redis 7.0.2, and it could not be installed without an S3 bucket.

### What changed

- Outline `1.9.2`, Postgres `17-alpine`, Redis `7.4-alpine`.
- Removed the `dockerfileLines` override that ran `yarn db:migrate --env production-ssl-disabled; yarn start`. Current Outline images run pending migrations themselves on startup (`server/scripts/checkMigrations.ts`), so a plain `image:` is enough and there is no build step anymore.
- **`FILE_STORAGE` now defaults to `local`** with a persistent volume at `/var/lib/outline/data`, so the app installs without an S3 bucket. The S3 fields are still available for anyone who sets `File storage` to `s3`.
- `websocketSupport: 'true'` is set in the template, so users no longer have to enable it by hand after installing.
- Fixed the redis volume: it was mounted over `/redis.conf`, it is now `/data`, with AOF turned on.
- Added the OIDC variables, generated defaults for `SECRET_KEY`/`UTILS_SECRET` (Outline requires exactly 64 hex characters), and restricted the database password to alphanumerics since it goes inside `DATABASE_URL`.
- Rewrote the instructions. The first visit now shows a "Create workspace" form that creates the admin account, but the sign-in page is empty afterwards until SMTP, Google or OIDC is configured, so that is called out explicitly.

### Testing

Deployed from this template on a real CapRover server (1.14.2), under a fresh app name:

- All three services came up: `outline-t1-db` (Postgres 17.10), `outline-t1-redis` (Redis 7.4 with AOF), `outline-t1`.
- Outline ran its migrations on first boot and started listening on 3000.
- `https://<app>.<domain>/` returns 200 with `<title>Outline</title>`, `/_health` returns `OK`, and http redirects to https with a 301.
- WebSocket upgrade against `/realtime/` returns **101 Switching Protocols**, confirming the websocket setting works without manual configuration.
- The "Create workspace" screen appeared on first visit and creating the admin account worked.

Also verified locally with `docker`, against `outlinewiki/outline:1.9.2`:

- `Entrypoint: [docker-entrypoint.sh]`, `Cmd: [node build/server/index.js]`, `User: nodejs` — no `command` is set for Outline, so the image starts exactly as upstream intends.
- The container reaches `healthy`, and every optional variable left empty is accepted (Outline treats empty strings as unset).
- The uploads directory is writable by the non-root user through the named volume.
- The redis `command` was checked with the entrypoint replaced (`docker run --entrypoint="" redis:7.4-alpine redis-server --appendonly yes`), since CapRover maps `command` onto `ContainerSpec.Command`.

Screenshot of a fresh install:

<!-- attach scratchpad/outline-t1.png here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modernized the Outline deployment template for current releases.
  * Added persistent storage and protected Redis configuration.
  * Added support for websockets, local or S3-compatible storage, OIDC authentication, secure SMTP, and forced HTTPS.
  * Updated deployment defaults and validation for versions, secrets, credentials, uploads, language, and authentication.

* **Documentation**
  * Expanded setup guidance for workspaces, HTTPS, migrations, redirects, websockets, authentication options, and backup locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### ☑️ Self Check before Merge

- [x] I have tested the template using the method described in README.md thoroughly
- [x] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [x] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [x] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [x] Icon is added as a png file to the logos directory. *(this is an update to an existing app, `logos/outline.png` is already there and unchanged)*
- [x] I've executed the checks if necessary by running `npm ci && npm run validate_apps && npm run formatter`
- [x] I will take responsibility addressing any issues that arises as a result of this PR (maintaining this app).