### PR TITLE
Document GitHub Pages setup for forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The included workflow validates, builds, and publishes the repository when chang
 - Enable GitHub Actions on your fork.
 - Go to **Settings → Pages**.
 - Under **Build and deployment**, set **Source** to **GitHub Actions**.
-- Leave [public/CNAME](https://github.com/caprover/one-click-apps/blob/master/public/CNAME) empty to use GitHub's default Pages domain. To use a custom domain, replace its contents with your domain and configure the same domain under **Settings → Pages**.
+- To use a custom domain, configure it under **Settings → Pages** and add the [required DNS records](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) with your domain provider. The GitHub Actions publishing workflow ignores `public/CNAME`.
 - Push your changes to `master`.
 
 The default repository URL is `https://<owner>.github.io/one-click-apps`. No personal access token is required.

--- a/README.md
+++ b/README.md
@@ -83,11 +83,22 @@ You may want to build your own private repository. CapRover supports having mult
 To create your own repository:
 - Fork this repository
 - Delete all existing apps (to avoid duplicate apps), and add your own apps.
-- Run `npm i`
+- Run `npm ci`
 - Run `npm run validate_apps`
 - Run `npm run formatter-write`
 - Run `npm run build`
-- Now you can host the static content placed in `./dist` directory anywhere you want, the official repo uses [github pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) to publish the content. Make sure to update [CNAME](https://github.com/caprover/one-click-apps/blob/master/public/CNAME) to your own URL if you decide to do so.
+- Host the static content in `./dist` using any static file server, or use the included GitHub Pages workflow described below.
+
+### Publishing with GitHub Pages
+The included workflow validates, builds, and publishes the repository when changes are pushed to `master`.
+
+- Enable GitHub Actions on your fork.
+- Go to **Settings → Pages**.
+- Under **Build and deployment**, set **Source** to **GitHub Actions**.
+- Leave [public/CNAME](https://github.com/caprover/one-click-apps/blob/master/public/CNAME) empty to use GitHub's default Pages domain. To use a custom domain, replace its contents with your domain and configure the same domain under **Settings → Pages**.
+- Push your changes to `master`.
+
+The default repository URL is `https://<owner>.github.io/one-click-apps`. No personal access token is required.
  
 ### Hosting your own repository on a CapRover instance
 Your own private repository can be hosted on a CapRover instance with the newly-added [captain-definition](/captain-definition) file.


### PR DESCRIPTION
## Summary

Update the self-hosted repository documentation to match the native GitHub Pages workflow introduced in #1320.

- Explain how to enable GitHub Actions on a fork
- Explain how to select GitHub Actions as the Pages publishing source
- Document default-domain and custom-domain `CNAME` handling
- Clarify that pushes to `master` publish automatically
- Clarify that no personal access token is required
- Separate GitHub Pages publishing from hosting the generated `dist` directory elsewhere
- Use `npm ci` for the documented reproducible install

## Why

The previous instructions described manually building `dist` and mentioned that the official repository used GitHub Pages, but they did not explain how a fork should enable the new artifact-based deployment workflow. Following the old section after #1320 would leave users without the repository settings required to publish.

## Impact

Fork owners get a complete setup path for either GitHub Pages or another static file host. There are no runtime or workflow changes.

## Validation

- Reviewed the instructions against the workflow currently on `master`
- Ran `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated repository publishing instructions to use `npm ci`.
  * Clarified how built content is hosted from the `dist` directory.
  * Added GitHub Pages setup guidance, including Actions, Pages configuration, custom domains, and the default site URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->